### PR TITLE
Remove jcenter repository

### DIFF
--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -1,8 +1,3 @@
-repositories {
-    // Yes jcenter is slated for extermination, we just need to wait for proguard to move over
-    jcenter()
-}
-
 configurations {
     proGuard
 }
@@ -16,7 +11,6 @@ dependencies {
     implementation 'org.quiltmc:procyon-quilt-compilertools:0.5.35.local' // TODO: Fix the buildscript
     implementation 'org.quiltmc:cfr:0.0.6'
 
-    // TODO: When will proguard publish to something other than jcenter
     proGuard 'com.guardsquare:proguard-base:7.1.0'
 }
 


### PR DESCRIPTION
ProGuard is now published to Maven Central