### PR TITLE
Fix enigma-cli and engima-swing publications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,16 +46,16 @@ subprojects {
         it.options.release = 16
     }
 
-//    publishing {
-//        publications {
-//            "$project.name"(MavenPublication) {
-//                groupId project.group
-//                artifactId project.name
-//                version project.version
-//                from components.java
-//            }
-//        }
-//    }
+   publishing {
+       publications {
+           "$project.name"(MavenPublication) {
+               groupId project.group
+               artifactId project.name
+               version project.version
+               from components.java
+           }
+       }
+   }
 }
 
 allprojects {

--- a/enigma-server/build.gradle
+++ b/enigma-server/build.gradle
@@ -11,13 +11,3 @@ mainClassName = 'cuchaz.enigma.network.DedicatedEnigmaServer'
 
 jar.manifest.attributes 'Main-Class': mainClassName
 
-publishing {
-    publications {
-        "$project.name"(MavenPublication) {
-            groupId project.group
-            artifactId project.name
-            version project.version
-            from components.java
-        }
-    }
-}

--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -61,13 +61,3 @@ file('src/test/java/cuchaz/enigma/inputs').listFiles().each { theFile ->
 
 test.dependsOn 'translationTestObf'
 
-publishing {
-    publications {
-        "$project.name"(MavenPublication) {
-            groupId project.group
-            artifactId project.name
-            version project.version
-            from components.java
-        }
-    }
-}


### PR DESCRIPTION
Currently only the shadow jar is published for enigma-cli and enigma-swing.