### PR TITLE
Fix mapping stats not skipping anonymous classes

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/stats/StatsGenerator.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/stats/StatsGenerator.java
@@ -122,7 +122,7 @@ public class StatsGenerator {
     }
 
     private void update(Map<String, Integer> counts, Entry<?> entry) {
-        if (project.isObfuscated(entry)) {
+        if (project.isObfuscated(entry) && project.isRenamable(entry)) {
             String parent = mapper.deobfuscate(entry.getAncestry().get(0)).getName().replace('/', '.');
             counts.put(parent, counts.getOrDefault(parent, 0) + 1);
         }

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/stats/StatsGenerator.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/stats/StatsGenerator.java
@@ -122,7 +122,7 @@ public class StatsGenerator {
     }
 
     private void update(Map<String, Integer> counts, Entry<?> entry) {
-        if (project.isObfuscated(entry) && project.isRenamable(entry)) {
+        if (project.isObfuscated(entry) && project.isRenamable(entry) && !project.isSynthetic(entry)) {
             String parent = mapper.deobfuscate(entry.getAncestry().get(0)).getName().replace('/', '.');
             counts.put(parent, counts.getOrDefault(parent, 0) + 1);
         }

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -19,6 +19,8 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
+import cuchaz.enigma.analysis.index.InnerClassIndex;
+import cuchaz.enigma.analysis.index.JarIndexer;
 import cuchaz.enigma.api.service.ObfuscationTestService;
 import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
@@ -171,6 +173,16 @@ public class EnigmaProject {
 			}
 		} else if (obfEntry instanceof LocalVariableEntry && !((LocalVariableEntry) obfEntry).isArgument()) {
 			return false;
+		} else if (obfEntry instanceof ClassEntry classEntry) {
+			InnerClassIndex innerClassIndex = jarIndex.getInnerClassIndex();
+			if (innerClassIndex.isInnerClass(classEntry) && innerClassIndex.hasOuterClassData(classEntry)) {
+				JarIndexer.InnerClassData innerClassData = innerClassIndex.getInnerClassData(classEntry);
+				JarIndexer.OuterClassData outerClassData = innerClassIndex.getOuterClassData(classEntry);
+				if (!innerClassData.hasInnerName() && outerClassData.hasEnclosingMethod()) {
+					// Anonymous classes don't have inner names
+					return false;
+				}
+			}
 		}
 
 		return this.jarIndex.getEntryIndex().hasEntry(obfEntry);

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -177,9 +177,8 @@ public class EnigmaProject {
 			InnerClassIndex innerClassIndex = jarIndex.getInnerClassIndex();
 			if (innerClassIndex.isInnerClass(classEntry) && innerClassIndex.hasOuterClassData(classEntry)) {
 				JarIndexer.InnerClassData innerClassData = innerClassIndex.getInnerClassData(classEntry);
-				JarIndexer.OuterClassData outerClassData = innerClassIndex.getOuterClassData(classEntry);
-				if (!innerClassData.hasInnerName() && outerClassData.hasEnclosingMethod()) {
-					// Anonymous classes don't have inner names
+				if (!innerClassData.hasInnerName() && !innerClassData.hasOuterName()) {
+					// Anonymous classes don't have inner or outer names
 					return false;
 				}
 			}

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -221,6 +221,10 @@ public class EnigmaProject {
 		return true;
 	}
 
+	public boolean isSynthetic(Entry<?> entry) {
+		return jarIndex.getEntryIndex().hasEntry(entry) && jarIndex.getEntryIndex().getEntryAccess(entry).isSynthetic();
+	}
+
 	public JarExport exportRemappedJar(ProgressListener progress) {
 		Collection<ClassEntry> classEntries = jarIndex.getEntryIndex().getClasses();
 		ClassProvider fixingClassProvider = new ObfuscationFixClassProvider(classProvider, jarIndex);

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/EntryIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/EntryIndex.java
@@ -79,6 +79,8 @@ public class EntryIndex implements JarIndexer {
 			return getFieldAccess(fieldEntry);
 		} else if (entry instanceof LocalVariableEntry localVariableEntry) {
 			return getMethodAccess(localVariableEntry.getParent());
+		} else if (entry instanceof ClassEntry classEntry) {
+			return getClassAccess(classEntry);
 		}
 
 		return null;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
@@ -25,6 +25,20 @@ public class IndexClassVisitor extends ClassVisitor {
 	}
 
 	@Override
+	public void visitInnerClass(String name, String outerName, String innerName, int access) {
+		indexer.indexInnerClass(classEntry, new JarIndexer.InnerClassData(name, outerName, innerName, access));
+
+		super.visitInnerClass(name, outerName, innerName, access);
+	}
+
+	@Override
+	public void visitOuterClass(String owner, String name, String descriptor) {
+		indexer.indexOuterClass(classEntry, new JarIndexer.OuterClassData(owner, name, descriptor));
+
+		super.visitOuterClass(owner, name, descriptor);
+	}
+
+	@Override
 	public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
 		indexer.indexField(FieldDefEntry.parse(classEntry, access, name, desc, signature));
 

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/InnerClassIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/InnerClassIndex.java
@@ -1,0 +1,53 @@
+package cuchaz.enigma.analysis.index;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class InnerClassIndex implements JarIndexer {
+    private Multimap<ClassDefEntry, InnerClassData> innerClasses = ArrayListMultimap.create();
+    private Map<ClassDefEntry, OuterClassData> outerClassesData = new HashMap<>();
+
+    @Override
+    public void indexInnerClass(ClassDefEntry classEntry, InnerClassData innerClassData) {
+        innerClasses.put(classEntry, innerClassData);
+    }
+
+    @Override
+    public void indexOuterClass(ClassDefEntry classEntry, OuterClassData outerClassData) {
+        outerClassesData.put(classEntry, outerClassData);
+    }
+
+    private Optional<Map.Entry<ClassDefEntry, InnerClassData>> findInnerClassEntry(ClassEntry classEntry) {
+        return innerClasses.entries().stream().filter(entry -> entry.getValue().name().equals(classEntry.getFullName())).findFirst();
+    }
+
+    public boolean isInnerClass(ClassEntry classEntry) {
+        return findInnerClassEntry(classEntry).isPresent();
+    }
+
+    public InnerClassData getInnerClassData(ClassEntry classEntry) {
+        return findInnerClassEntry(classEntry).map(Map.Entry::getValue).orElse(null);
+    }
+
+    public ClassDefEntry getOuterClass(ClassEntry classEntry) {
+        return findInnerClassEntry(classEntry).map(Map.Entry::getKey).orElse(null);
+    }
+
+    private Optional<Map.Entry<ClassDefEntry, OuterClassData>> findOuterClassDataEntry(ClassEntry classEntry) {
+        return outerClassesData.entrySet().stream().filter(entry -> entry.getKey().equals(classEntry)).findFirst();
+    }
+
+    public boolean hasOuterClassData(ClassEntry classEntry) {
+        return findOuterClassDataEntry(classEntry).isPresent();
+    }
+
+    public OuterClassData getOuterClassData(ClassEntry classEntry) {
+        return findOuterClassDataEntry(classEntry).map(Map.Entry::getValue).orElse(null);
+    }
+}

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndexer.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndexer.java
@@ -23,6 +23,28 @@ public interface JarIndexer {
 	default void indexLambda(MethodDefEntry callerEntry, Lambda lambda, ReferenceTargetType targetType) {
 	}
 
+	default void indexInnerClass(ClassDefEntry classEntry, InnerClassData innerClassData) {
+	}
+
+	default void indexOuterClass(ClassDefEntry classEntry, OuterClassData outerClassData) {
+	}
+
 	default void processIndex(JarIndex index) {
+	}
+
+	record InnerClassData(String name, String innerName, String outerName, int access) {
+		public boolean hasInnerName() {
+			return innerName != null;
+		}
+
+		public boolean hasOuterName() {
+			return outerName != null;
+		}
+	}
+
+	record OuterClassData(String owner, String name, String descriptor) {
+		public boolean hasEnclosingMethod() {
+			return name != null && descriptor != null;
+		}
 	}
 }


### PR DESCRIPTION
Adds indexing of inner & enclosing classes, since it's the only way to properly detect an anonymous class