### PR TITLE
add a resize button to dockers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
     }
 
     group = 'org.quiltmc'
-    version = '1.4.0'
+    version = '1.5.0'
 
     var ENV = System.getenv()
     version = version + (ENV.GITHUB_ACTIONS ? (ENV.SNAPSHOTS_URL ? "-SNAPSHOT" : "") : "+local")

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ subprojects {
     }
 
     group = 'org.quiltmc'
-    version = '1.5.0'
+    version = '1.4.0'
 
     var ENV = System.getenv()
     version = version + (ENV.GITHUB_ACTIONS ? (ENV.SNAPSHOTS_URL ? "-SNAPSHOT" : "") : "+local")

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/Dock.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/Dock.java
@@ -14,6 +14,7 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -138,7 +139,7 @@ public class Dock extends JPanel {
 		this.host(docker, verticalLocation, true);
 	}
 
-	private void host(Docker docker, Docker.VerticalLocation verticalLocation, boolean avoidEmptySpace) {
+	public void host(Docker docker, Docker.VerticalLocation verticalLocation, boolean avoidEmptySpace) {
 		Dock dock = Util.findDock(docker);
 		if (dock != null) {
 			dock.removeDocker(verticalLocation, avoidEmptySpace);
@@ -148,9 +149,9 @@ public class Dock extends JPanel {
 			case BOTTOM, TOP -> {
 				// if we'd be leaving empty space via opening, we want to host the docker as the full panel
 				// this is to avoid wasting space
-				if (avoidEmptySpace && (this.isSplit && this.getDock(verticalLocation.inverse()).getHostedDocker() == null)
+				if (avoidEmptySpace && ((this.isSplit && this.getDock(verticalLocation.inverse()).getHostedDocker() == null)
 						|| (!this.isSplit && this.unifiedDock.getHostedDocker() == null)
-						|| (!this.isSplit && this.unifiedDock.getHostedDocker().getId().equals(docker.getId()))) {
+						|| (!this.isSplit && this.unifiedDock.getHostedDocker().getId().equals(docker.getId())))) {
 					this.host(docker, Docker.VerticalLocation.FULL);
 					return;
 				}
@@ -364,6 +365,9 @@ public class Dock extends JPanel {
 			if (this.hostedDocker != null) {
 				this.add(this.hostedDocker);
 				this.hostedDocker.setVisible(true);
+
+				// since the docker is being hosted, we know that findLocation will succeed
+				this.hostedDocker.getTitleBar().updateResizeButton(Objects.requireNonNull(Util.findLocation(hostedDocker)).verticalLocation());
 			}
 		}
 	}

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/Docker.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/Docker.java
@@ -55,6 +55,10 @@ public abstract class Docker extends JPanel {
 		this.title.retranslateUi();
 	}
 
+	public DockerTitleBar getTitleBar() {
+		return this.title;
+	}
+
 	/**
 	 * @return the side panel button that opens and closes this docker
 	 */

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/component/DockerTitleBar.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/component/DockerTitleBar.java
@@ -6,17 +6,34 @@ import cuchaz.enigma.gui.docker.Dock;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import java.awt.BorderLayout;
+import java.awt.FlowLayout;
 import java.awt.Insets;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 public class DockerTitleBar extends JPanel {
+	private static final String SPLIT_ICON = "◫";
+	private static final String FULLSCREEN_ICON = "□";
+
 	private final Supplier<String> titleSupplier;
 	private final DockerLabel label;
+	private final JButton resizeButton;
 
 	public DockerTitleBar(Docker parent, Supplier<String> titleSupplier) {
-		super(new BorderLayout());
+		super(new BorderLayout(0, 0));
 		this.label = new DockerLabel(parent, titleSupplier.get());
 		this.titleSupplier = titleSupplier;
+		this.resizeButton = new JButton(SPLIT_ICON);
+
+		this.resizeButton.addActionListener(e -> {
+			boolean split = this.resizeButton.getText().equals(SPLIT_ICON);
+
+			// since the button can only be pressed on a visible docker, we can assume the location will always be found
+			Docker.VerticalLocation location = split ? Docker.VerticalLocation.TOP : Docker.VerticalLocation.FULL;
+			Objects.requireNonNull(Dock.Util.findDock(parent)).host(parent, location, false);
+			this.updateResizeButton(location);
+		});
+
 		JButton minimiseButton = new JButton("-");
 
 		minimiseButton.addActionListener(e -> {
@@ -26,11 +43,23 @@ public class DockerTitleBar extends JPanel {
 
 		// if we set the left and right margins to 4, the button lines up *really* cutely with the scroll bar in any JScrollPane underneath it
 		minimiseButton.setMargin(new Insets(0, 4, 0, 4));
+		this.resizeButton.setMargin(new Insets(0, 4, 0, 4));
+
+		// by default, flow layout applies a 5px gap between components
+		// we want to avoid this vertically to make sure the title bar is as compact as possible
+		FlowLayout layout = new FlowLayout(FlowLayout.LEFT, 0, 0);
+		JPanel buttons = new JPanel(layout);
+		buttons.add(this.resizeButton);
+		buttons.add(minimiseButton);
 
 		// set up
 		this.add(this.label, BorderLayout.WEST);
-		this.add(minimiseButton, BorderLayout.EAST);
+		this.add(buttons, BorderLayout.EAST);
 		this.label.setConstraints(BorderLayout.WEST);
+	}
+
+	public void updateResizeButton(Docker.VerticalLocation location) {
+		this.resizeButton.setText(location == Docker.VerticalLocation.FULL ? SPLIT_ICON : FULLSCREEN_ICON);
 	}
 
 	public void retranslateUi() {


### PR DESCRIPTION
ignore the four "bump version" commits I promise I'm really smart and didn't struggle to release 1.5.0 all by myself

this pr adds a new button next to a docker's minimise button, "resize"
when pressed, it will either host its docker fullscreen in its dock or split it, moving it to the top position and leaving the bottom open for another docker. this aims to make it easier to build a layout
it has an icon which is one of `◫` or `□` depending on which action it's going to perform

screenshots:
![image](https://user-images.githubusercontent.com/66223394/214996195-4252a272-199c-4146-9482-68b48e171a1c.png)
![image](https://user-images.githubusercontent.com/66223394/214996301-f99249cf-869a-4740-837e-3e1da333b089.png)
