### PR TITLE
temporarily remove shadowing warning

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingValidator.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingValidator.java
@@ -14,8 +14,6 @@ import cuchaz.enigma.translation.representation.entry.Entry;
 import cuchaz.enigma.utils.validation.Message;
 import cuchaz.enigma.utils.validation.ValidationContext;
 
-import javax.annotation.Nullable;
-
 public class MappingValidator {
 	private final EntryTree<EntryMapping> obfToDeobf;
 	private final Translator deobfuscator;
@@ -42,7 +40,6 @@ public class MappingValidator {
 		Collection<ClassEntry> relatedClasses = this.getRelatedClasses(containingClass);
 
 		boolean error = false;
-		Entry<?> shadowedEntry;
 
 		for (ClassEntry relatedClass : relatedClasses) {
 			if (this.isStatic(entry) && relatedClass != containingClass) {
@@ -66,13 +63,6 @@ public class MappingValidator {
 					vc.raise(Message.NONUNIQUE_NAME, name);
 				}
 				error = true;
-			} else if ((shadowedEntry = this.getShadowedEntry(translatedEntry, translatedSiblings, name)) != null) {
-				Entry<?> parent = shadowedEntry.getParent();
-				if (parent != null) {
-					vc.raise(Message.SHADOWED_NAME_CLASS, name, parent);
-				} else {
-					vc.raise(Message.SHADOWED_NAME, name);
-				}
 			}
 		}
 
@@ -101,20 +91,6 @@ public class MappingValidator {
 
 	private boolean canConflict(Entry<?> entry, Entry<?> sibling) {
 		return entry.canConflictWith(sibling);
-	}
-
-	@Nullable
-	private Entry<?> getShadowedEntry(Entry<?> entry, List<? extends Entry<?>> siblings, String name) {
-		for (Entry<?> sibling : siblings) {
-			if (this.canShadow(entry, sibling) && sibling.getName().equals(name)) {
-				return sibling;
-			}
-		}
-		return null;
-	}
-
-	private boolean canShadow(Entry<?> entry, Entry<?> sibling) {
-		return entry.canShadow(sibling);
 	}
 
 	private boolean isStatic(Entry<?> entry) {

--- a/enigma/src/main/java/cuchaz/enigma/utils/validation/Message.java
+++ b/enigma/src/main/java/cuchaz/enigma/utils/validation/Message.java
@@ -15,9 +15,6 @@ public class Message {
 	public static final Message ILLEGAL_DOC_COMMENT_END = create(Type.ERROR, "illegal_doc_comment_end");
 	public static final Message UNKNOWN_RECORD_GETTER = create(Type.ERROR, "unknown_record_getter");
 
-	public static final Message SHADOWED_NAME_CLASS = create(Type.WARNING, "shadowed_name_class");
-	public static final Message SHADOWED_NAME = create(Type.WARNING, "shadowed_name");
-
 	public static final Message SERVER_STARTED = create(Type.INFO, "server_started");
 	public static final Message CONNECTED_TO_SERVER = create(Type.INFO, "connected_to_server");
 	public static final Message LEFT_SERVER = create(Type.INFO, "left_server");


### PR DESCRIPTION
does not remove all underlying code, since I want to bring it back. however, this has been broken since its introduction, and with the new notification system, it shows itself far too often, even with no shadowing issues present.

example of it showing up when it shouldn't (I've just renamed `register`, the one with the caret on it):
![image](https://user-images.githubusercontent.com/66223394/219540372-b4e95f67-a146-4570-9fc7-28b11d4c7624.png)

notes:
fixes #55 