### PR TITLE
fix calls tree navigation crash

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -369,6 +369,7 @@ public class GuiController implements ClientPacketHandler {
 			// entry is not in the jar. Ignore it
 			return;
 		}
+
 		this.openDeclaration(entry);
 	}
 
@@ -376,6 +377,7 @@ public class GuiController implements ClientPacketHandler {
 		if (!this.project.isNavigable(reference.getLocationClassEntry())) {
 			return;
 		}
+
 		this.openReference(reference);
 	}
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/CallsTreeDocker.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/docker/CallsTreeDocker.java
@@ -14,6 +14,7 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 
+import cuchaz.enigma.analysis.EntryReference;
 import cuchaz.enigma.analysis.ReferenceTreeNode;
 import cuchaz.enigma.gui.Gui;
 import cuchaz.enigma.gui.TokenListCellRenderer;
@@ -83,6 +84,7 @@ public class CallsTreeDocker extends Docker {
 		this.tokens.setListData(new Vector<>());
 	}
 
+	@SuppressWarnings("unchecked")
 	private void onTreeClicked(MouseEvent event) {
 		if (event.getClickCount() >= 2 && event.getButton() == MouseEvent.BUTTON1) {
 			// get the selected node
@@ -96,7 +98,7 @@ public class CallsTreeDocker extends Docker {
 
 			if (node instanceof ReferenceTreeNode<?, ?> referenceNode) {
 				if (referenceNode.getReference() != null) {
-					this.gui.getController().navigateTo((Entry<?>) referenceNode.getReference());
+					this.gui.getController().navigateTo((EntryReference<Entry<?>, Entry<?>>) referenceNode.getReference());
 				} else {
 					this.gui.getController().navigateTo(referenceNode.getEntry());
 				}


### PR DESCRIPTION
code cleanup pr added an improper cast which led to the wrong method being called, which then led to a crash