### PR TITLE
rework Enigma's handling of inner classes

### DIFF
--- a/enigma-server/src/main/java/cuchaz/enigma/network/packet/PacketHelper.java
+++ b/enigma-server/src/main/java/cuchaz/enigma/network/packet/PacketHelper.java
@@ -40,7 +40,13 @@ public class PacketHelper {
 					throw new IOException("Class requires class parent");
 				}
 
-				return new ClassEntry((ClassEntry) parent, name, javadocs);
+				String simpleName;
+				if (input.readBoolean()) {
+					simpleName = input.readBoolean() ? readString(input) : null;
+				} else {
+					simpleName = ClassEntry.getSimpleName(name);
+				}
+				return new ClassEntry((ClassEntry) parent, name, simpleName, javadocs);
 			}
 			case ENTRY_FIELD -> {
 				if (!(parent instanceof ClassEntry parentClass)) {
@@ -107,7 +113,16 @@ public class PacketHelper {
 		}
 
 		// type-specific stuff
-		if (entry instanceof FieldEntry fieldEntry) {
+		if (entry instanceof ClassEntry classEntry) {
+			output.writeBoolean(classEntry.hasOuterClass());
+			if (classEntry.hasOuterClass()) {
+				String simpleName = classEntry.getSimpleName();
+				output.writeBoolean(simpleName != null);
+				if (simpleName != null) {
+					writeString(output, simpleName);
+				}
+			}
+		} else if (entry instanceof FieldEntry fieldEntry) {
 			writeString(output, fieldEntry.getDesc().toString());
 		} else if (entry instanceof MethodEntry methodEntry) {
 			writeString(output, methodEntry.getDesc().toString());

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/ClassSelector.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/ClassSelector.java
@@ -149,8 +149,7 @@ public class ClassSelector extends JTree {
 						}
 					}
 					if (allowEdit && ClassSelector.this.renameSelectionListener != null) {
-						Object prevData = node.getUserObject();
-						Object objectData = node.getUserObject() instanceof ClassEntry ? new ClassEntry(((ClassEntry) prevData).getPackageName() + "/" + data) : data;
+						Object objectData = node.getUserObject() instanceof ClassEntry classEntry ? classEntry.withName(data) : data;
 
 						ValidationContext context = new ValidationContext(null);
 						ClassSelector.this.renameSelectionListener.onSelectionRename(context, node.getUserObject(), objectData, node);

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -396,7 +396,7 @@ public class GuiController implements ClientPacketHandler {
 
 		Collection<ClassEntry> classes = this.project.getJarIndex().getEntryIndex().getClasses();
 		Stream<ClassEntry> visibleClasses = classes.stream()
-				.filter(entry -> !entry.isInnerClass());
+				.filter(entry -> !entry.hasOuterClass());
 
 		visibleClasses.forEach(entry -> {
 			TranslateResult<ClassEntry> result = mapper.extendedDeobfuscate(entry);
@@ -515,7 +515,7 @@ public class GuiController implements ClientPacketHandler {
 			this.chp.invalidateJavadoc(target.getTopLevelClass());
 		}
 
-		if (renamed && target instanceof ClassEntry classEntry && !classEntry.isInnerClass()) {
+		if (renamed && target instanceof ClassEntry classEntry && !classEntry.hasOuterClass()) {
 			this.gui.moveClassTree(target, prev.targetName() == null, mapping.targetName() == null);
 			return;
 		}

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -128,7 +128,7 @@ public class SearchDialog {
 
 		switch (type) {
 			case CLASS -> entryIndex.getClasses().parallelStream()
-					.filter(e -> !e.isInnerClass())
+					.filter(e -> !e.hasOuterClass())
 					.map(e -> SearchEntryImpl.from(e, this.parent.getController()))
 					.map(SearchUtil.Entry::from)
 					.sequential()

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/IdentifierPanel.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/panels/IdentifierPanel.java
@@ -95,8 +95,8 @@ public class IdentifierPanel {
 						throw new IllegalStateException("constructor method entry to render has no parent!");
 					}
 
-					name = parent.isInnerClass() ? parent.getName() : parent.getFullName();
-				} else if (this.deobfEntry instanceof ClassEntry classEntry && !classEntry.isInnerClass()) {
+					name = parent.hasOuterClass() ? parent.getSimpleName() : parent.getFullName();
+				} else if (this.deobfEntry instanceof ClassEntry classEntry && !classEntry.hasOuterClass()) {
 					name = classEntry.getFullName();
 				} else {
 					name = this.deobfEntry.getName();
@@ -120,7 +120,7 @@ public class IdentifierPanel {
 			this.ui.setEnabled(true);
 
 			if (this.deobfEntry instanceof ClassEntry ce) {
-				String name = ce.isInnerClass() ? ce.getName() : ce.getFullName();
+				String name = ce.hasOuterClass() ? ce.getSimpleName() : ce.getFullName();
 				this.nameField = th.addRenameTextField(EditableType.CLASS, name);
 				th.addCopiableStringRow(I18n.translate("info_panel.identifier.obfuscated"), this.entry.getName());
 				th.addModifierRow(I18n.translate("info_panel.identifier.modifier"), EditableType.CLASS, this::onModifierChanged);
@@ -134,7 +134,7 @@ public class IdentifierPanel {
 				if (me.isConstructor()) {
 					ClassEntry ce = me.getParent();
 					if (ce != null) {
-						String name = ce.isInnerClass() ? ce.getName() : ce.getFullName();
+						String name = ce.hasOuterClass() ? ce.getSimpleName() : ce.getFullName();
 						this.nameField = th.addRenameTextField(EditableType.CLASS, name);
 					}
 				} else {

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -2,8 +2,8 @@ package cuchaz.enigma;
 
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
+
 import cuchaz.enigma.analysis.EntryReference;
-import cuchaz.enigma.analysis.index.EnclosingMethodIndex;
 import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.api.service.NameProposalService;
 import cuchaz.enigma.api.service.ObfuscationTestService;
@@ -151,7 +151,7 @@ public class EnigmaProject {
 	}
 
 	public boolean isNavigable(Entry<?> obfEntry) {
-		if (obfEntry instanceof ClassEntry classEntry && this.isAnonymousOrLocal(classEntry)) {
+		if (obfEntry instanceof ClassEntry classEntry && this.isAnonymous(classEntry)) {
 			return false;
 		}
 
@@ -185,7 +185,7 @@ public class EnigmaProject {
 			}
 		} else if (obfEntry instanceof LocalVariableEntry localEntry && !localEntry.isArgument()) {
 			return false;
-		} else if (obfEntry instanceof ClassEntry classEntry && this.isAnonymousOrLocal(classEntry)) {
+		} else if (obfEntry instanceof ClassEntry classEntry && this.isAnonymous(classEntry)) {
 			return false;
 		}
 
@@ -223,10 +223,10 @@ public class EnigmaProject {
 		return this.jarIndex.getEntryIndex().hasEntry(entry) && this.jarIndex.getEntryIndex().getEntryAccess(entry).isSynthetic();
 	}
 
-	public boolean isAnonymousOrLocal(ClassEntry classEntry) {
-		EnclosingMethodIndex enclosingMethodIndex = this.jarIndex.getEnclosingMethodIndex();
+	public boolean isAnonymous(ClassEntry classEntry) {
 		// Only local and anonymous classes may have the EnclosingMethod attribute
-		return enclosingMethodIndex.hasEnclosingMethod(classEntry);
+		// but anonymous classes do not have simple names, while local classes do
+		return classEntry.getSimpleName() == null && this.jarIndex.getEnclosingMethodIndex().hasEnclosingMethod(classEntry);
 	}
 
 	public JarExport exportRemappedJar(ProgressListener progress) {

--- a/enigma/src/main/java/cuchaz/enigma/analysis/ClassDefBuilder.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/ClassDefBuilder.java
@@ -1,0 +1,70 @@
+package cuchaz.enigma.analysis;
+
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InnerClassNode;
+
+import cuchaz.enigma.analysis.index.EntryIndex;
+import cuchaz.enigma.analysis.index.JarIndexer;
+import cuchaz.enigma.classprovider.ClassProvider;
+import cuchaz.enigma.translation.representation.AccessFlags;
+import cuchaz.enigma.translation.representation.Signature;
+import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+
+public class ClassDefBuilder {
+
+	private final JarIndexer indexer;
+	private final EntryIndex entryIndex;
+	private final ClassProvider classProvider;
+
+	public ClassDefBuilder(JarIndexer indexer, EntryIndex entryIndex, ClassProvider classProvider) {
+		this.indexer = indexer;
+		this.entryIndex = entryIndex;
+		this.classProvider = classProvider;
+	}
+
+	public ClassDefEntry build(String className) {
+		return (ClassDefEntry)buildClassEntry(className);
+	}
+
+	private ClassEntry buildClassEntry(String className) {
+		ClassEntry entry = new ClassEntry(className);
+		ClassNode classNode = this.classProvider.get(className);
+
+		if (classNode == null) {
+			return entry;
+		}
+
+		ClassDefEntry classEntry = this.entryIndex.getDefinition(entry);
+
+		if (classEntry == null) {
+			classEntry = buildClassEntry(classNode);
+		}
+
+		return classEntry;
+	}
+
+	private ClassDefEntry buildClassEntry(ClassNode classNode) {
+		ClassEntry outerClass = (classNode.outerClass == null) ? null : buildClassEntry(classNode.outerClass);
+		ClassEntry superClass = (classNode.superName == null) ? null : buildClassEntry(classNode.superName);
+		ClassEntry[] interfaces = classNode.interfaces.stream().map(this::buildClassEntry).toArray(ClassEntry[]::new);
+		Signature signature = Signature.createSignature(classNode.signature);
+		AccessFlags access = new AccessFlags(classNode.access);
+
+		ClassDefEntry classEntry = new ClassDefEntry(outerClass, classNode.name, this.findSimpleName(classNode), signature, access, superClass, interfaces);
+		this.indexer.indexClass(classEntry);
+
+		return classEntry;
+	}
+
+	private String findSimpleName(ClassNode classNode) {
+		for (InnerClassNode innerClass : classNode.innerClasses) {
+			// classes also hold references to other inner classes
+			if (innerClass.name.equals(classNode.name)) {
+				return innerClass.innerName;
+			}
+		}
+
+		return ClassEntry.getSimpleName(classNode.name);
+	}
+}

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
@@ -1,6 +1,7 @@
 package cuchaz.enigma.analysis.index;
 
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.FieldDefEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
 import org.objectweb.asm.ClassVisitor;
@@ -9,17 +10,18 @@ import org.objectweb.asm.MethodVisitor;
 
 public class IndexClassVisitor extends ClassVisitor {
 	private final JarIndexer indexer;
+	private final EntryIndex entryIndex;
 	private ClassDefEntry classEntry;
 
-	public IndexClassVisitor(JarIndex indexer, int api) {
+	public IndexClassVisitor(JarIndexer indexer, EntryIndex entryIndex, int api) {
 		super(api);
 		this.indexer = indexer;
+		this.entryIndex = entryIndex;
 	}
 
 	@Override
 	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-		this.classEntry = ClassDefEntry.parse(access, name, signature, superName, interfaces);
-		this.indexer.indexClass(this.classEntry);
+		this.classEntry = this.entryIndex.getDefinition(new ClassEntry(name));
 
 		super.visit(version, access, name, signature, superName, interfaces);
 	}

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexReferenceVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexReferenceVisitor.java
@@ -34,7 +34,7 @@ public class IndexReferenceVisitor extends ClassVisitor {
 
 	@Override
 	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-		this.classEntry = new ClassEntry(name);
+		this.classEntry = this.entryIndex.getDefinition(new ClassEntry(name));
 		this.className = name;
 	}
 

--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
@@ -1,9 +1,12 @@
 package cuchaz.enigma.bytecode.translators;
 
 import com.google.common.base.CharMatcher;
+
+import cuchaz.enigma.analysis.index.EntryIndex;
 import cuchaz.enigma.translation.LocalNameGenerator;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Label;
@@ -15,15 +18,17 @@ import java.util.List;
 import java.util.Map;
 
 public class LocalVariableFixVisitor extends ClassVisitor {
+	private final EntryIndex entryIndex;
 	private ClassDefEntry ownerEntry;
 
-	public LocalVariableFixVisitor(int api, ClassVisitor visitor) {
+	public LocalVariableFixVisitor(int api, ClassVisitor visitor, EntryIndex entryIndex) {
 		super(api, visitor);
+		this.entryIndex = entryIndex;
 	}
 
 	@Override
 	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-		this.ownerEntry = ClassDefEntry.parse(access, name, signature, superName, interfaces);
+		this.ownerEntry = this.entryIndex.getDefinition(new ClassEntry(name));
 		super.visit(version, access, name, signature, superName, interfaces);
 	}
 

--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/SourceFixVisitor.java
@@ -3,6 +3,7 @@ package cuchaz.enigma.bytecode.translators;
 import cuchaz.enigma.analysis.index.BridgeMethodIndex;
 import cuchaz.enigma.analysis.index.JarIndex;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -20,7 +21,7 @@ public class SourceFixVisitor extends ClassVisitor {
 
 	@Override
 	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-		this.ownerEntry = ClassDefEntry.parse(access, name, signature, superName, interfaces);
+		this.ownerEntry = this.index.getEntryIndex().getDefinition(new ClassEntry(name));
 		super.visit(version, access, name, signature, superName, interfaces);
 	}
 

--- a/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classhandle/ClassHandleProvider.java
@@ -133,7 +133,7 @@ public final class ClassHandleProvider {
 				e.invalidateJavadoc();
 			}
 
-			if (entry.isInnerClass()) {
+			if (entry.hasOuterClass()) {
 				this.invalidateJavadoc(entry.getOuterClass());
 			}
 		});

--- a/enigma/src/main/java/cuchaz/enigma/classprovider/ObfuscationFixClassProvider.java
+++ b/enigma/src/main/java/cuchaz/enigma/classprovider/ObfuscationFixClassProvider.java
@@ -50,7 +50,7 @@ public class ObfuscationFixClassProvider implements ClassProvider {
 
 		ClassNode fixedNode = new ClassNode();
 		ClassVisitor visitor = fixedNode;
-		visitor = new LocalVariableFixVisitor(Enigma.ASM_VERSION, visitor);
+		visitor = new LocalVariableFixVisitor(Enigma.ASM_VERSION, visitor, this.jarIndex.getEntryIndex());
 		visitor = new SourceFixVisitor(Enigma.ASM_VERSION, visitor, this.jarIndex);
 		node.accept(visitor);
 		this.removeRedundantClassCalls(fixedNode);

--- a/enigma/src/main/java/cuchaz/enigma/source/procyon/EntryParser.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/procyon/EntryParser.java
@@ -28,7 +28,7 @@ public class EntryParser {
 		AccessFlags access = new AccessFlags(def.getModifiers());
 		ClassEntry superClass = def.getBaseType() != null ? parse(def.getBaseType()) : null;
 		ClassEntry[] interfaces = def.getExplicitInterfaces().stream().map(EntryParser::parse).toArray(ClassEntry[]::new);
-		return new ClassDefEntry(name, signature, access, superClass, interfaces);
+		return new ClassDefEntry(null, name, ClassEntry.getSimpleName(name), signature, access, superClass, interfaces);
 	}
 
 	public static ClassEntry parse(TypeReference typeReference) {

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsReader.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsReader.java
@@ -215,13 +215,9 @@ public enum EnigmaMappingsReader implements MappingsReader {
 	}
 
 	private static MappingPair<ClassEntry, RawEntryMapping> parseClass(@Nullable Entry<?> parent, String[] tokens) {
-		String obfuscatedName = ClassEntry.getInnerName(tokens[1]);
-		ClassEntry obfuscatedEntry;
-		if (parent instanceof ClassEntry classEntry) {
-			obfuscatedEntry = new ClassEntry(classEntry, obfuscatedName);
-		} else {
-			obfuscatedEntry = new ClassEntry(obfuscatedName);
-		}
+		String fullName = tokens[1];
+		String simpleName = ClassEntry.getSimpleName(fullName);
+		ClassEntry obfuscatedEntry = new ClassEntry((ClassEntry) parent, fullName, simpleName, null);
 
 		String mapping = null;
 		AccessModifier modifier = AccessModifier.UNCHANGED;
@@ -230,7 +226,7 @@ public enum EnigmaMappingsReader implements MappingsReader {
 			AccessModifier parsedModifier = parseModifier(tokens[2]);
 			if (parsedModifier != null) {
 				modifier = parsedModifier;
-				mapping = obfuscatedName;
+				mapping = null;
 			} else {
 				mapping = tokens[2];
 			}

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/proguard/ProguardMappingsReader.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/proguard/ProguardMappingsReader.java
@@ -52,7 +52,7 @@ public class ProguardMappingsReader implements MappingsReader {
 				String targetName = classMatcher.group(2);
 
 				currentClass = new ClassEntry(name.replace('.', '/'));
-				mappings.insert(currentClass, new EntryMapping(ClassEntry.getInnerName(targetName.replace('.', '/'))));
+				mappings.insert(currentClass, new EntryMapping(ClassEntry.stripOuterClassName(targetName.replace('.', '/'))));
 			} else if (fieldMatcher.matches()) {
 				String type = fieldMatcher.group(1);
 				String name = fieldMatcher.group(2);


### PR DESCRIPTION
This PR serves as a replacement for #63 by reworking how Enigma handles inner classes. I made some big changes and have not fully tested it, so it's still very much WIP.

The core issue is how Enigma deduces two pieces of information about an inner class: its outer class and its inner name. Enigma assumes this information is encoded in the class' internal name. By convention this is the case, as inner class names tend to have the format `path/to/OuterClass$InnerName`, but this is not required by the JVM spec, and already breaks down with anonymous and local classes.

This is fixed by taking this information from the inner class attributes in the class file. This allows for proper remapping of all inner and local classes, but also comes with a few drawbacks.
- The `ClassEntry(String)` constructor now becomes risky to use, as it assumes the given class name is from a top level class. Class entries for inner classes should be made with the `ClassEntry(ClassEntry, String, String)` constructor instead.
- None of the mapping formats support inner classes properly. They all assume class names follow convention in one way or another. For example, the tiny formats only deal with a class' internal name, and an inner class' simple name will have to be inferred from that. Meanwhile, the Enigma format only identifies inner classes by their inner name (or rather, the inner name as inferred from the class' internal name) and the class' internal name will have to be inferred from that.