### PR TITLE
fix inner classes displaying far too many class names

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/source/SourceRemapper.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/SourceRemapper.java
@@ -22,12 +22,6 @@ public class SourceRemapper {
 
 			String remappedName = remapper.remap(token, movedToken);
 
-			// fixes a bug where the remapped name was displaying each and every inner class (e.g A.A.B.A.B.C instead of simply A.B.C)
-			// we do this by removing everything but the last class in the name (eg A.B.C -> C)
-			if (remappedName != null && remappedName.contains(".")) {
-				remappedName = remappedName.substring(remappedName.lastIndexOf('.') + 1);
-			}
-
 			if (remappedName != null) {
 				accumulatedOffset += movedToken.getRenameOffset(remappedName);
 				movedToken.rename(remappedSource, remappedName);

--- a/enigma/src/main/java/cuchaz/enigma/source/SourceRemapper.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/SourceRemapper.java
@@ -13,7 +13,7 @@ public class SourceRemapper {
 	}
 
 	public Result remap(Remapper remapper) {
-		StringBuffer remappedSource = new StringBuffer(this.source);
+		StringBuilder remappedSource = new StringBuilder(this.source);
 		Map<Token, Token> remappedTokens = new HashMap<>();
 
 		int accumulatedOffset = 0;
@@ -21,6 +21,13 @@ public class SourceRemapper {
 			Token movedToken = token.move(accumulatedOffset);
 
 			String remappedName = remapper.remap(token, movedToken);
+
+			// fixes a bug where the remapped name was displaying each and every inner class (e.g A.A.B.A.B.C instead of simply A.B.C)
+			// we do this by removing everything but the last class in the name (eg A.B.C -> C)
+			if (remappedName != null && remappedName.contains(".")) {
+				remappedName = remappedName.substring(remappedName.lastIndexOf('.') + 1);
+			}
+
 			if (remappedName != null) {
 				accumulatedOffset += movedToken.getRenameOffset(remappedName);
 				movedToken.rename(remappedSource, remappedName);

--- a/enigma/src/main/java/cuchaz/enigma/source/Token.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/Token.java
@@ -30,7 +30,7 @@ public class Token implements Comparable<Token> {
 		return to.length() - this.length();
 	}
 
-	public void rename(StringBuffer source, String to) {
+	public void rename(StringBuilder source, String to) {
 		int oldEnd = this.end;
 		this.text = to;
 		this.end = this.start + to.length();
@@ -55,7 +55,7 @@ public class Token implements Comparable<Token> {
 
 	@Override
 	public boolean equals(Object other) {
-		return other instanceof Token && this.equals((Token) other);
+		return other instanceof Token token && this.equals(token);
 	}
 
 	@Override

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -73,6 +73,11 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 	}
 
 	@Override
+	public String getSourceRemapName() {
+		return this.getSimpleName();
+	}
+
+	@Override
 	public String getContextualName() {
 		if (this.isInnerClass()) {
 			return this.parent.getSimpleName() + "$" + this.name;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -239,15 +239,6 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 	}
 
 	@Override
-	public String getSourceRemapName() {
-		ClassEntry outerClass = this.getOuterClass();
-		if (outerClass != null) {
-			return outerClass.getSourceRemapName() + "." + this.name;
-		}
-		return this.getSimpleName();
-	}
-
-	@Override
 	public int compareTo(ClassEntry entry) {
 		String name = this.getFullName();
 		String otherFullName = entry.getFullName();


### PR DESCRIPTION
this fixes that obnoxious bug where things would show:
![bug](https://media.discordapp.net/attachments/877319390901706753/1085685781085048872/image.png?width=959&height=50)
now that looks like this:
![fixed :)](https://media.discordapp.net/attachments/1071967909510922361/1086481823007260813/image.png)