### PR TITLE
ignore entries that no longer exist from recent files in gui

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/MenuBar.java
@@ -455,6 +455,10 @@ public class MenuBar {
 		}
 
 		for (Pair<Path, Path> recent : recentFilePairs) {
+			if (!Files.exists(recent.a()) || !Files.exists(recent.b())) {
+				continue;
+			}
+
 			String jarName = recent.a().getFileName().toString();
 
 			// if there's no common prefix, just show the last directory in the tree


### PR DESCRIPTION
this fixes a crash when you opened a deleted file from the recent menu

notes:
fixes #70 