### PR TITLE
remove cuchaz license headers

### DIFF
--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.command;
 
 import cuchaz.enigma.Enigma;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/BrowserCaret.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/BrowserCaret.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 import javax.swing.text.DefaultCaret;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/ClassSelector.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/ClassSelector.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 import cuchaz.enigma.gui.config.keybind.KeyBinds;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/ExceptionIgnorer.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/ExceptionIgnorer.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 public class ExceptionIgnorer {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Gui.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 import cuchaz.enigma.Enigma;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 import java.awt.Desktop;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/Main.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 import java.io.IOException;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/ReadableToken.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/ReadableToken.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 public class ReadableToken {

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/TokenListCellRenderer.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/TokenListCellRenderer.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui;
 
 import cuchaz.enigma.source.Token;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/AboutDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/AboutDialog.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.dialog;
 
 import java.awt.Container;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/CrashDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/CrashDialog.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.dialog;
 
 import cuchaz.enigma.Enigma;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/JavadocDialog.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.dialog;
 
 import java.awt.BorderLayout;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/ProgressDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/ProgressDialog.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.dialog;
 
 import java.awt.Container;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/dialog/SearchDialog.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.dialog;
 
 import java.awt.BorderLayout;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.highlight;
 
 import java.awt.Color;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/SelectionHighlightPainter.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/SelectionHighlightPainter.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.highlight;
 
 import java.awt.*;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/node/ClassSelectorClassNode.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/node/ClassSelectorClassNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.node;
 
 import cuchaz.enigma.ProgressListener;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/node/ClassSelectorPackageNode.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/node/ClassSelectorPackageNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.node;
 
 import cuchaz.enigma.translation.representation.entry.ClassEntry;

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/InheritanceTreeCellRenderer.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/renderer/InheritanceTreeCellRenderer.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.gui.renderer;
 
 import java.awt.Component;

--- a/enigma/src/main/java/cuchaz/enigma/Enigma.java
+++ b/enigma/src/main/java/cuchaz/enigma/Enigma.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import java.io.IOException;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/Access.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/Access.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import cuchaz.enigma.translation.representation.AccessFlags;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/ClassImplementationsTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/ClassImplementationsTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import cuchaz.enigma.analysis.index.InheritanceIndex;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/ClassInheritanceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/ClassInheritanceTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import cuchaz.enigma.analysis.index.InheritanceIndex;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/ClassReferenceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/ClassReferenceTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import com.google.common.collect.Sets;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/EntryReference.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/EntryReference.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import java.util.Arrays;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/FieldReferenceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/FieldReferenceTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import cuchaz.enigma.analysis.index.JarIndex;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/MethodImplementationsTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/MethodImplementationsTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import cuchaz.enigma.analysis.index.EntryIndex;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/MethodInheritanceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/MethodInheritanceTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import cuchaz.enigma.analysis.index.EntryIndex;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/MethodReferenceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/MethodReferenceTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import com.google.common.collect.Sets;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/ReferenceTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/ReferenceTreeNode.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis;
 
 import cuchaz.enigma.translation.representation.entry.Entry;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/InheritanceIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/InheritanceIndex.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis.index;
 
 import com.google.common.collect.HashMultimap;

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/JarIndex.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.analysis.index;
 
 import com.google.common.collect.ArrayListMultimap;

--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/TranslationClassVisitor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.bytecode.translators;
 
 import cuchaz.enigma.translation.Translator;

--- a/enigma/src/main/java/cuchaz/enigma/source/Token.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/Token.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.source;
 
 public class Token implements Comparable<Token> {

--- a/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexClassVisitor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.source.procyon.index;
 
 import com.strobel.assembler.metadata.FieldDefinition;

--- a/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexMethodVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexMethodVisitor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.source.procyon.index;
 
 import com.google.common.collect.HashMultimap;

--- a/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/procyon/index/SourceIndexVisitor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.source.procyon.index;
 
 import com.strobel.assembler.metadata.TypeDefinition;

--- a/enigma/src/main/java/cuchaz/enigma/translation/SignatureUpdater.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/SignatureUpdater.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation;
 
 import java.io.IOException;

--- a/enigma/src/main/java/cuchaz/enigma/translation/TranslationDirection.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/TranslationDirection.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation;
 
 public enum TranslationDirection {

--- a/enigma/src/main/java/cuchaz/enigma/translation/Translator.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/Translator.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation;
 
 import java.util.Collection;

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/IdentifierValidation.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/IdentifierValidation.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.mapping;
 
 import java.util.List;

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingsChecker.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/MappingsChecker.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.mapping;
 
 import cuchaz.enigma.ProgressListener;

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingParseException.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/MappingParseException.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.mapping.serde;
 
 import java.io.File;

--- a/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsWriter.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/mapping/serde/enigma/EnigmaMappingsWriter.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.mapping.serde.enigma;
 
 import java.io.IOException;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation;
 
 import java.util.ArrayList;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/TypeDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/TypeDescriptor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation;
 
 import java.util.Map;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassDefEntry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import java.util.Arrays;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ClassEntry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import cuchaz.enigma.source.RenamableTokenType;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/Entry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/Entry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import java.util.ArrayList;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldDefEntry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import com.google.common.base.Preconditions;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/FieldEntry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import java.util.Objects;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodDefEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodDefEntry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import javax.annotation.Nonnull;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/MethodEntry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import java.util.Objects;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/entry/ParentedEntry.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.representation.entry;
 
 import javax.annotation.Nonnull;

--- a/enigma/src/main/java/cuchaz/enigma/utils/Utils.java
+++ b/enigma/src/main/java/cuchaz/enigma/utils/Utils.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- * <p>
- * Contributors:
- * Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.utils;
 
 import com.google.common.io.CharStreams;

--- a/enigma/src/test/java/cuchaz/enigma/PackageVisibilityIndexTest.java
+++ b/enigma/src/test/java/cuchaz/enigma/PackageVisibilityIndexTest.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.analysis.index.JarIndex;

--- a/enigma/src/test/java/cuchaz/enigma/TestDeobfed.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestDeobfed.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.classprovider.ClasspathClassProvider;

--- a/enigma/src/test/java/cuchaz/enigma/TestDeobfuscator.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestDeobfuscator.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.classprovider.ClasspathClassProvider;

--- a/enigma/src/test/java/cuchaz/enigma/TestEntryFactory.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestEntryFactory.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.analysis.EntryReference;

--- a/enigma/src/test/java/cuchaz/enigma/TestInnerClasses.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestInnerClasses.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.analysis.index.JarIndex;

--- a/enigma/src/test/java/cuchaz/enigma/TestJarIndexConstructorReferences.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestJarIndexConstructorReferences.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.analysis.EntryReference;

--- a/enigma/src/test/java/cuchaz/enigma/TestJarIndexInheritanceTree.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestJarIndexInheritanceTree.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.analysis.EntryReference;

--- a/enigma/src/test/java/cuchaz/enigma/TestJarIndexLoneClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestJarIndexLoneClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.analysis.*;

--- a/enigma/src/test/java/cuchaz/enigma/TestMethodDescriptor.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestMethodDescriptor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.translation.representation.MethodDescriptor;

--- a/enigma/src/test/java/cuchaz/enigma/TestTokensConstructors.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestTokensConstructors.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.source.Decompilers;

--- a/enigma/src/test/java/cuchaz/enigma/TestTranslator.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestTranslator.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.classprovider.ClasspathClassProvider;

--- a/enigma/src/test/java/cuchaz/enigma/TestTypeDescriptor.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestTypeDescriptor.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.translation.representation.TypeDescriptor;

--- a/enigma/src/test/java/cuchaz/enigma/TokenChecker.java
+++ b/enigma/src/test/java/cuchaz/enigma/TokenChecker.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma;
 
 import cuchaz.enigma.analysis.EntryReference;

--- a/enigma/src/test/java/cuchaz/enigma/inputs/Keep.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/Keep.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs;
 
 public class Keep {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/constructors/BaseClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/constructors/BaseClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.constructors;
 
 // a

--- a/enigma/src/test/java/cuchaz/enigma/inputs/constructors/Caller.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/constructors/Caller.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.constructors;
 
 // b

--- a/enigma/src/test/java/cuchaz/enigma/inputs/constructors/DefaultConstructable.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/constructors/DefaultConstructable.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.constructors;
 
 public class DefaultConstructable {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/constructors/SubClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/constructors/SubClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.constructors;
 
 // d extends a

--- a/enigma/src/test/java/cuchaz/enigma/inputs/constructors/SubSubClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/constructors/SubSubClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.constructors;
 
 // e extends d

--- a/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/BaseClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/BaseClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.inheritanceTree;
 
 // a

--- a/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/SubclassA.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/SubclassA.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.inheritanceTree;
 
 // b extends a

--- a/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/SubclassB.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/SubclassB.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.inheritanceTree;
 
 // c extends a

--- a/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/SubsubclassAA.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/inheritanceTree/SubsubclassAA.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.inheritanceTree;
 
 // d extends b

--- a/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/A_Anonymous.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/A_Anonymous.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.innerClasses;
 
 @SuppressWarnings("Convert2Lambda")

--- a/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/B_AnonymousWithScopeArgs.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/B_AnonymousWithScopeArgs.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.innerClasses;
 
 public class B_AnonymousWithScopeArgs {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/C_ConstructorArgs.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/C_ConstructorArgs.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.innerClasses;
 
 @SuppressWarnings("unused")

--- a/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/D_Simple.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/D_Simple.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.innerClasses;
 
 public class D_Simple {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/E_AnonymousWithOuterAccess.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/E_AnonymousWithOuterAccess.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.innerClasses;
 
 public class E_AnonymousWithOuterAccess {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/F_ClassTree.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/innerClasses/F_ClassTree.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.innerClasses;
 
 public class F_ClassTree {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/loneClass/LoneClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/loneClass/LoneClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.loneClass;
 
 public class LoneClass {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/A_Basic.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/A_Basic.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 public class A_Basic {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/B_BaseClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/B_BaseClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 public class B_BaseClass {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/C_SubClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/C_SubClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 public class C_SubClass extends B_BaseClass {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/D_AnonymousTesting.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/D_AnonymousTesting.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 import java.util.ArrayList;

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/E_Bridges.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/E_Bridges.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 import java.util.Iterator;

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/F_ObjectMethods.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/F_ObjectMethods.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 @SuppressWarnings("FinalizeCalledExplicitly")

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/G_OuterClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/G_OuterClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 public class G_OuterClass {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/H_NamelessClass.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/H_NamelessClass.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 public class H_NamelessClass {

--- a/enigma/src/test/java/cuchaz/enigma/inputs/translation/I_Generics.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/translation/I_Generics.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.inputs.translation;
 
 import java.util.List;

--- a/enigma/src/test/java/cuchaz/enigma/translation/mapping/TestTinyV2InnerClasses.java
+++ b/enigma/src/test/java/cuchaz/enigma/translation/mapping/TestTinyV2InnerClasses.java
@@ -1,14 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2015 Jeff Martin.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public
- * License v3.0 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
- *
- * Contributors:
- *	 Jeff Martin - initial API and implementation
- ******************************************************************************/
-
 package cuchaz.enigma.translation.mapping;
 
 import cuchaz.enigma.Enigma;


### PR DESCRIPTION
this pull request removes cuchaz's old license headers, since they have become inconsistent over the years, only being present in a few files at this point.

permission obtained via mastodon:
![image](https://user-images.githubusercontent.com/66223394/228267661-77cb6332-3eb6-4c23-8ec6-a7a95dcf5b32.png)
