### PR TITLE
fix bad disconnect messages

### DIFF
--- a/enigma-server/src/main/java/cuchaz/enigma/network/EnigmaClient.java
+++ b/enigma-server/src/main/java/cuchaz/enigma/network/EnigmaClient.java
@@ -36,18 +36,18 @@ public class EnigmaClient {
 					} catch (EOFException | SocketException e) {
 						break;
 					}
+
 					Packet<ClientPacketHandler> packet = PacketRegistry.createS2CPacket(packetId);
 					if (packet == null) {
 						throw new IOException("Received invalid packet id " + packetId);
 					}
+
 					packet.read(input);
 					SwingUtilities.invokeLater(() -> packet.handle(this.controller));
 				}
 			} catch (IOException e) {
 				this.controller.disconnectIfConnected(e.toString());
-				return;
 			}
-			this.controller.disconnectIfConnected("Disconnected");
 		});
 		thread.setName("Client I/O thread");
 		thread.setDaemon(true);

--- a/enigma-server/src/main/java/cuchaz/enigma/network/EnigmaServer.java
+++ b/enigma-server/src/main/java/cuchaz/enigma/network/EnigmaServer.java
@@ -114,7 +114,9 @@ public abstract class EnigmaServer {
 	}
 
 	public void kick(Socket client, String reason) {
-		if (!this.clients.remove(client)) return;
+		if (!this.clients.remove(client)) {
+			return;
+		}
 
 		this.sendPacket(client, new KickS2CPacket(reason));
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/GuiController.java
@@ -585,12 +585,14 @@ public class GuiController implements ClientPacketHandler {
 
 		if (this.client != null) {
 			this.client.disconnect();
+			this.client = null;
 		}
+
 		if (this.server != null) {
 			this.server.stop();
+			this.server = null;
 		}
-		this.client = null;
-		this.server = null;
+
 		SwingUtilities.invokeLater(() -> {
 			if (reason != null) {
 				JOptionPane.showMessageDialog(this.gui.getFrame(), I18n.translate(reason), I18n.translate("disconnect.disconnected"), JOptionPane.INFORMATION_MESSAGE);


### PR DESCRIPTION
removes a bad line of code that would show a second (unhelpful) disconnect dialog, which hid the original (helpful) one.

fixes #77 