### PR TITLE
fix enum statistics counting

### DIFF
--- a/enigma/src/main/java/cuchaz/enigma/Enigma.java
+++ b/enigma/src/main/java/cuchaz/enigma/Enigma.java
@@ -12,6 +12,7 @@ import cuchaz.enigma.classprovider.CachingClassProvider;
 import cuchaz.enigma.classprovider.ClassProvider;
 import cuchaz.enigma.classprovider.CombiningClassProvider;
 import cuchaz.enigma.classprovider.JarClassProvider;
+import cuchaz.enigma.classprovider.ObfuscationFixClassProvider;
 import cuchaz.enigma.utils.I18n;
 import cuchaz.enigma.utils.Utils;
 import com.google.common.base.Preconditions;
@@ -53,10 +54,10 @@ public class Enigma {
 
 	public EnigmaProject openJar(Path path, ClassProvider libraryClassProvider, ProgressListener progress) throws IOException {
 		JarClassProvider jarClassProvider = new JarClassProvider(path);
-		ClassProvider classProvider = new CachingClassProvider(new CombiningClassProvider(jarClassProvider, libraryClassProvider));
+		JarIndex index = JarIndex.empty();
+		ClassProvider classProvider = new ObfuscationFixClassProvider(new CachingClassProvider(new CombiningClassProvider(jarClassProvider, libraryClassProvider)), index);
 		Set<String> scope = jarClassProvider.getClassNames();
 
-		JarIndex index = JarIndex.empty();
 		index.indexJar(scope, classProvider, progress);
 
 		var indexers = this.services.getWithIds(JarIndexerService.TYPE);

--- a/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
+++ b/enigma/src/main/java/cuchaz/enigma/EnigmaProject.java
@@ -185,6 +185,14 @@ public class EnigmaProject {
 			}
 		} else if (obfEntry instanceof LocalVariableEntry localEntry && !localEntry.isArgument()) {
 			return false;
+		} else if (obfEntry instanceof LocalVariableEntry localEntry && localEntry.isArgument()) {
+			MethodEntry method = localEntry.getParent();
+			ClassDefEntry parent = this.jarIndex.getEntryIndex().getDefinition(method.getParent());
+
+			// if this is the valueOf method of an enum class, the argument shouldn't be able to be renamed.
+			if (parent.isEnum() && method.getName().equals("valueOf") && method.getDesc().toString().equals("(Ljava/lang/String;)L" + parent.getFullName() + ";")) {
+				return false;
+			}
 		} else if (obfEntry instanceof ClassEntry classEntry && this.isAnonymousOrLocal(classEntry)) {
 			return false;
 		}

--- a/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/StructureTreeNode.java
@@ -110,7 +110,7 @@ public class StructureTreeNode extends DefaultMutableTreeNode {
 			result = result + ": " + returnType;
 		} else if (this.entry instanceof MethodDefEntry) {
 			MethodDefEntry method = (MethodDefEntry) translateResult.getValue();
-			String args = this.parseArgs(method.getDesc().getArgumentDescs());
+			String args = this.parseArgs(method.getDesc().getTypeDescs());
 			String returnType = this.parseDesc(method.getDesc().getReturnDesc());
 
 			if (method.isConstructor()) {

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/BridgeMethodIndex.java
@@ -2,6 +2,7 @@ package cuchaz.enigma.analysis.index;
 
 import com.google.common.collect.Maps;
 import cuchaz.enigma.translation.representation.AccessFlags;
+import cuchaz.enigma.translation.representation.ArgumentDescriptor;
 import cuchaz.enigma.translation.representation.MethodDescriptor;
 import cuchaz.enigma.translation.representation.TypeDescriptor;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
@@ -101,8 +102,8 @@ public class BridgeMethodIndex implements JarIndexer {
 
 		MethodDescriptor bridgeDesc = bridgeMethod.getDesc();
 		MethodDescriptor specializedDesc = specializedMethod.getDesc();
-		List<TypeDescriptor> bridgeArguments = bridgeDesc.getArgumentDescs();
-		List<TypeDescriptor> specializedArguments = specializedDesc.getArgumentDescs();
+		List<ArgumentDescriptor> bridgeArguments = bridgeDesc.getArgumentDescs();
+		List<ArgumentDescriptor> specializedArguments = specializedDesc.getArgumentDescs();
 
 		// A bridge method will always have the same number of arguments
 		if (bridgeArguments.size() != specializedArguments.size()) {

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
@@ -1,5 +1,7 @@
 package cuchaz.enigma.analysis.index;
 
+import cuchaz.enigma.analysis.MethodNodeWithAction;
+import cuchaz.enigma.translation.representation.accessflags.ParameterAccessFlags;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import cuchaz.enigma.translation.representation.entry.FieldDefEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
@@ -41,8 +43,17 @@ public class IndexClassVisitor extends ClassVisitor {
 
 	@Override
 	public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-		this.indexer.indexMethod(MethodDefEntry.parse(this.classEntry, access, name, desc, signature));
+		MethodDefEntry entry = MethodDefEntry.parse(this.classEntry, access, name, desc, signature);
 
-		return super.visitMethod(access, name, desc, signature, exceptions);
+		return new MethodNodeWithAction(this.api, access, name, desc, signature, exceptions, methodNode -> {
+			// add parameter access values to the entry
+			if (methodNode.parameters != null) {
+				for (int i = 0; i < methodNode.parameters.size(); i++) {
+					entry.getDesc().getArgumentDescs().get(i).setAccess(new ParameterAccessFlags(methodNode.parameters.get(i).access));
+				}
+			}
+
+			this.indexer.indexMethod(entry);
+		});
 	}
 }

--- a/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/analysis/index/IndexClassVisitor.java
@@ -1,7 +1,7 @@
 package cuchaz.enigma.analysis.index;
 
 import cuchaz.enigma.analysis.MethodNodeWithAction;
-import cuchaz.enigma.translation.representation.accessflags.ParameterAccessFlags;
+import cuchaz.enigma.translation.representation.ParameterAccessFlags;
 import cuchaz.enigma.translation.representation.entry.ClassDefEntry;
 import cuchaz.enigma.translation.representation.entry.FieldDefEntry;
 import cuchaz.enigma.translation.representation.entry.MethodDefEntry;

--- a/enigma/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
+++ b/enigma/src/main/java/cuchaz/enigma/bytecode/translators/LocalVariableFixVisitor.java
@@ -45,7 +45,7 @@ public class LocalVariableFixVisitor extends ClassVisitor {
 			this.methodEntry = methodEntry;
 
 			int lvIndex = methodEntry.getAccess().isStatic() ? 0 : 1;
-			List<TypeDescriptor> parameters = methodEntry.getDesc().getArgumentDescs();
+			List<TypeDescriptor> parameters = methodEntry.getDesc().getTypeDescs();
 			for (int parameterIndex = 0; parameterIndex < parameters.size(); parameterIndex++) {
 				TypeDescriptor param = parameters.get(parameterIndex);
 				this.parameterIndices.put(lvIndex, parameterIndex);
@@ -80,7 +80,7 @@ public class LocalVariableFixVisitor extends ClassVisitor {
 		@Override
 		public void visitEnd() {
 			if (!this.hasParameterTable) {
-				List<TypeDescriptor> arguments = this.methodEntry.getDesc().getArgumentDescs();
+				List<TypeDescriptor> arguments = this.methodEntry.getDesc().getTypeDescs();
 				for (int argumentIndex = 0; argumentIndex < arguments.size(); argumentIndex++) {
 					super.visitParameter(this.fixParameterName(argumentIndex, null), this.fixParameterAccess(argumentIndex, 0));
 				}
@@ -95,7 +95,7 @@ public class LocalVariableFixVisitor extends ClassVisitor {
 			}
 
 			if (this.isInvalidName(name)) {
-				List<TypeDescriptor> arguments = this.methodEntry.getDesc().getArgumentDescs();
+				List<TypeDescriptor> arguments = this.methodEntry.getDesc().getTypeDescs();
 				name = LocalNameGenerator.generateArgumentName(index, arguments.get(index), arguments);
 			}
 

--- a/enigma/src/main/java/cuchaz/enigma/source/DecompiledClassSource.java
+++ b/enigma/src/main/java/cuchaz/enigma/source/DecompiledClassSource.java
@@ -101,7 +101,7 @@ public class DecompiledClassSource {
 		if (entry instanceof LocalVariableDefEntry localVariable) {
 			int index = localVariable.getIndex();
 			if (localVariable.isArgument()) {
-				List<TypeDescriptor> arguments = localVariable.getParent().getDesc().getArgumentDescs();
+				List<TypeDescriptor> arguments = localVariable.getParent().getDesc().getTypeDescs();
 				return LocalNameGenerator.generateArgumentName(index, localVariable.getDesc(), arguments);
 			} else {
 				return LocalNameGenerator.generateLocalVariableName(index, localVariable.getDesc());

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/ArgumentDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/ArgumentDescriptor.java
@@ -1,0 +1,26 @@
+package cuchaz.enigma.translation.representation;
+
+import java.util.function.UnaryOperator;
+
+import cuchaz.enigma.translation.representation.accessflags.ParameterAccessFlags;
+
+public class ArgumentDescriptor extends TypeDescriptor {
+	private ParameterAccessFlags access;
+
+	public ArgumentDescriptor(String desc, ParameterAccessFlags access) {
+		super(desc);
+		this.access = access;
+	}
+
+	public ParameterAccessFlags getAccess() {
+		return this.access;
+	}
+
+	public void setAccess(ParameterAccessFlags access) {
+		this.access = access;
+	}
+
+	public ArgumentDescriptor remap(UnaryOperator<String> remapper) {
+		return new ArgumentDescriptor(super.remap(remapper).desc, this.getAccess());
+	}
+}

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/ArgumentDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/ArgumentDescriptor.java
@@ -2,8 +2,6 @@ package cuchaz.enigma.translation.representation;
 
 import java.util.function.UnaryOperator;
 
-import cuchaz.enigma.translation.representation.accessflags.ParameterAccessFlags;
-
 public class ArgumentDescriptor extends TypeDescriptor {
 	private ParameterAccessFlags access;
 

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/MethodDescriptor.java
@@ -6,7 +6,6 @@ import cuchaz.enigma.translation.Translator;
 import cuchaz.enigma.translation.mapping.EntryMap;
 import cuchaz.enigma.translation.mapping.EntryMapping;
 import cuchaz.enigma.translation.mapping.EntryResolver;
-import cuchaz.enigma.translation.representation.accessflags.ParameterAccessFlags;
 import cuchaz.enigma.translation.representation.entry.ClassEntry;
 
 import java.util.ArrayList;

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/ParameterAccessFlags.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/ParameterAccessFlags.java
@@ -1,4 +1,4 @@
-package cuchaz.enigma.translation.representation.accessflags;
+package cuchaz.enigma.translation.representation;
 
 import org.objectweb.asm.Opcodes;
 

--- a/enigma/src/main/java/cuchaz/enigma/translation/representation/accessflags/ParameterAccessFlags.java
+++ b/enigma/src/main/java/cuchaz/enigma/translation/representation/accessflags/ParameterAccessFlags.java
@@ -1,0 +1,21 @@
+package cuchaz.enigma.translation.representation.accessflags;
+
+import org.objectweb.asm.Opcodes;
+
+public class ParameterAccessFlags {
+	public static final ParameterAccessFlags DEFAULT = new ParameterAccessFlags(0);
+
+	private int flags;
+
+	public ParameterAccessFlags(int flags) {
+		this.flags = flags;
+	}
+
+	public boolean isSynthetic() {
+		return (this.flags & Opcodes.ACC_SYNTHETIC) != 0;
+	}
+
+	public boolean isFinal() {
+		return (this.flags & Opcodes.ACC_FINAL) != 0;
+	}
+}

--- a/enigma/src/test/java/cuchaz/enigma/TestJarIndexEnums.java
+++ b/enigma/src/test/java/cuchaz/enigma/TestJarIndexEnums.java
@@ -1,0 +1,43 @@
+package cuchaz.enigma;
+
+import org.junit.jupiter.api.Test;
+import cuchaz.enigma.classprovider.ClasspathClassProvider;
+import cuchaz.enigma.stats.StatType;
+import cuchaz.enigma.stats.StatsGenerator;
+import cuchaz.enigma.stats.StatsResult;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.EnumSet;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class TestJarIndexEnums {
+	public static final Path JAR = TestUtil.obfJar("enums");
+
+	@Test
+	void checkEnumStats() {
+		EnigmaProject project = openProject();
+		StatsResult stats = new StatsGenerator(project).generate(ProgressListener.none(), EnumSet.allOf(StatType.class), "", false);
+
+		assertThat(stats.getMapped(StatType.CLASSES), equalTo(0));
+		assertThat(stats.getMapped(StatType.FIELDS), equalTo(0));
+		assertThat(stats.getMapped(StatType.METHODS), equalTo(0));
+		assertThat(stats.getMapped(StatType.PARAMETERS), equalTo(0));
+
+		assertThat(stats.getMappable(StatType.CLASSES), equalTo(3));
+		assertThat(stats.getMappable(StatType.FIELDS), equalTo(17));
+		assertThat(stats.getMappable(StatType.METHODS), equalTo(4));
+		assertThat(stats.getMappable(StatType.PARAMETERS), equalTo(3));
+	}
+
+	private static EnigmaProject openProject() {
+		try {
+			Enigma enigma = Enigma.create();
+			return enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.none());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/enigma/src/test/java/cuchaz/enigma/inputs/enums/Color.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/enums/Color.java
@@ -1,0 +1,22 @@
+package cuchaz.enigma.inputs.enums;
+
+// this enum does not have its `values` or `valueOf` methods obfuscated.
+// (see proguard-enums-test.conf)
+public enum Color {
+	RED(0xff0000),
+	YELLOW(0xffff00),
+	GREEN(0x00ff00),
+	CYAN(0x00ffff),
+	BLUE(0x0000ff),
+	MAGENTA(0xff00ff);
+
+	public final int rgb;
+
+	Color(int rgb) {
+		this.rgb = rgb;
+	}
+
+	public int getColor() {
+		return this.rgb;
+	}
+}

--- a/enigma/src/test/java/cuchaz/enigma/inputs/enums/TestEnum.java
+++ b/enigma/src/test/java/cuchaz/enigma/inputs/enums/TestEnum.java
@@ -1,0 +1,14 @@
+package cuchaz.enigma.inputs.enums;
+
+public enum TestEnum {
+	One,
+	Two,
+	Three,
+	Four,
+	Five,
+	Six,
+	Seven,
+	Eight,
+	Nine,
+	Ten;
+}

--- a/enigma/src/test/resources/proguard-enums-test.conf
+++ b/enigma/src/test/resources/proguard-enums-test.conf
@@ -1,0 +1,12 @@
+-overloadaggressively
+-repackageclasses
+-allowaccessmodification
+-dontoptimize
+-dontshrink
+-keepparameternames
+-keepattributes
+-keep class cuchaz.enigma.inputs.Keep
+-keepclassmembers enum cuchaz.enigma.inputs.enums.Color {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}


### PR DESCRIPTION
fixes this by
- no longer counting synthetic parameters in the stats (unless specified)
- marking the parameter in the `valueOf` method of enums as unrenamable

fixes #113 