### PR TITLE
improve command help

### DIFF
--- a/enigma-cli/build.gradle
+++ b/enigma-cli/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-	implementation project(':enigma')
+	shadow(implementation project(':enigma'))
 	testImplementation(testFixtures(project(':enigma')))
 }
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Argument.java
@@ -35,7 +35,7 @@ public enum Argument {
 	),
 	KEEP_MODE("<keep-mode>",
 		"""
-				Which mappings that should be kept when composing mappings. Allowed values are "left", "right", and "both"."""
+				Which mappings should overwrite the others when composing conflicting mappings. Allowed values are "left", "right", and "both"."""
 	),
 	DECOMPILER("<decompiler>",
 		"""

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Argument.java
@@ -1,0 +1,88 @@
+package cuchaz.enigma.command;
+
+public enum Argument {
+	INPUT_JAR("<input-jar>",
+		"""
+				A path to the .jar file to use in executing the command."""
+	),
+	INPUT_MAPPINGS("<input-mappings>",
+		"""
+				A path to the file or folder to read mappings from."""
+	),
+	LEFT_MAPPINGS("<left-mappings>",
+		"""
+				A path to the left file or folder to read mappings from, used in commands which take two mapping inputs."""
+	),
+	RIGHT_MAPPINGS("<right-mappings>",
+		"""
+				A path to the right file or folder to read mappings from, used in commands which take two mapping inputs."""
+	),
+	OUTPUT_MAPPING_FORMAT("<output-mapping-format>",
+		"""
+				The mapping format to use when writing output mappings. Allowed values are (case-insensitive):
+				- TINY_V2:from_namespace:to_namespace (ex: tiny_v2:intermediary:named)
+				- ENIGMA_FILE
+				- ENIGMA_DIRECTORY
+				- ENIGMA_ZIP
+				- SRG_FILE
+				- RECAF
+
+				Proguard is not a valid output format, as writing is unsupported."""
+	),
+	MAPPING_OUTPUT("<mapping-output>",
+		"""
+				A path to the file or folder to write mappings to. Will be created if missing."""
+	),
+	KEEP_MODE("<keep-mode>",
+		"""
+				Which mappings that should be kept when composing mappings. Allowed values are "left", "right", and "both"."""
+	),
+	DECOMPILER("<decompiler>",
+		"""
+				The decompiler to use when producing output. Allowed values are (case-insensitive):
+				- VINEFLOWER
+				- CFR
+				- PROCYON
+				- BYTECODE"""
+	),
+	OUTPUT_FOLDER("<output-folder>",
+		"""
+				A path to the file or folder to write output to."""
+	),
+	OUTPUT_JAR("<output-jar>",
+		"""
+				A path to the .jar file to write output to. Will be created if missing."""
+	),
+	FILL_ALL("<fill-all>",
+		"""
+				Whether to fill all possible mappings. Allowed values are "true" and "false"."""
+	),
+	ENIGMA_PROFILE("<enigma-profile>",
+		"""
+				A path to an Enigma profile JSON file, used to apply things like plugins."""
+	);
+
+	private final String displayForm;
+	private final String explanation;
+
+	Argument(String displayForm, String explanation) {
+		this.displayForm = displayForm;
+		this.explanation = explanation;
+	}
+
+	public String getDisplayForm() {
+		return this.displayForm;
+	}
+
+	public String getExplanation() {
+		return this.explanation;
+	}
+
+	public ComposedArgument required() {
+		return new ComposedArgument(this, false);
+	}
+
+	public ComposedArgument optional() {
+		return new ComposedArgument(this, true);
+	}
+}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
@@ -29,7 +29,7 @@ public class CheckMappingsCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		return "Validates the mappings for umm... something? idk really this always produces an error when running the tests but like it doesn't fail them? what's going on here??";
+		return "Checks that the mappings can be applied on the jar and used without any runtime error, such as package-private members accessed from an invalid package";
 	}
 
 	public static void run(Path fileJarIn, Path fileMappings) throws Exception {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
@@ -18,8 +18,8 @@ public class CheckMappingsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws Exception {
-		Path fileJarIn = getReadableFile(getArg(args, 0, "in jar", true)).toPath();
-		Path fileMappings = getReadablePath(getArg(args, 1, "mappings file", true));
+		Path fileJarIn = getReadableFile(this.getArg(args, 0)).toPath();
+		Path fileMappings = getReadablePath(this.getArg(args, 1));
 		run(fileJarIn, fileMappings);
 	}
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
@@ -11,17 +11,9 @@ import java.util.stream.Collectors;
 
 public class CheckMappingsCommand extends Command {
 	public CheckMappingsCommand() {
-		super("checkmappings");
-	}
-
-	@Override
-	public String getUsage() {
-		return "<in jar> <mappings file>";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 2;
+		super("check-mappings",
+				Argument.INPUT_JAR.required(),
+				Argument.INPUT_MAPPINGS.required());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
@@ -29,7 +29,7 @@ public class CheckMappingsCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		return "Checks that the mappings can be applied on the jar and used without any runtime error, such as package-private members accessed from an invalid package";
+		return "Checks that the mappings can be applied on the jar and used without any runtime errors, such as package-private members accessed from an invalid package.";
 	}
 
 	public static void run(Path fileJarIn, Path fileMappings) throws Exception {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/CheckMappingsCommand.java
@@ -11,8 +11,7 @@ import java.util.stream.Collectors;
 
 public class CheckMappingsCommand extends Command {
 	public CheckMappingsCommand() {
-		super("check-mappings",
-				Argument.INPUT_JAR.required(),
+		super(Argument.INPUT_JAR.required(),
 				Argument.INPUT_MAPPINGS.required());
 	}
 
@@ -21,6 +20,16 @@ public class CheckMappingsCommand extends Command {
 		Path fileJarIn = getReadableFile(this.getArg(args, 0)).toPath();
 		Path fileMappings = getReadablePath(this.getArg(args, 1));
 		run(fileJarIn, fileMappings);
+	}
+
+	@Override
+	public String getName() {
+		return "check-mappings";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Validates the mappings for umm... something? idk really this always produces an error when running the tests but like it doesn't fail them? what's going on here??";
 	}
 
 	public static void run(Path fileJarIn, Path fileMappings) throws Exception {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
@@ -77,7 +77,7 @@ public abstract class Command {
 	 */
 	public boolean checkArgumentCount(int length) {
 		// valid if length is equal to the amount of required arguments or between required argument count and total argument count
-		return length == this.requiredArguments.size() || length > this.requiredArguments.size() && length <= this.requiredArguments.size() + this.optionalArguments.size();
+		return length == this.requiredArguments.size() || length > this.requiredArguments.size() && length <= this.allArguments.size();
 	}
 
 	/**

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
@@ -29,13 +29,11 @@ import java.util.Locale;
 import javax.annotation.Nullable;
 
 public abstract class Command {
-	public final String name;
 	protected final List<Argument> requiredArguments = new ArrayList<>();
 	protected final List<Argument> optionalArguments = new ArrayList<>();
 	protected final List<ComposedArgument> allArguments;
 
-	protected Command(String name, ComposedArgument... arguments) {
-		this.name = name;
+	protected Command(ComposedArgument... arguments) {
 		this.allArguments = new ArrayList<>();
 
 		for (ComposedArgument argument : arguments) {
@@ -82,7 +80,25 @@ public abstract class Command {
 		return length == this.requiredArguments.size() || length > this.requiredArguments.size() && length <= this.requiredArguments.size() + this.optionalArguments.size();
 	}
 
+	/**
+	 * Executes this command.
+	 * @param args the command-line arguments, to be parsed with {@link #getArg(String[], int)}
+	 * @throws Exception on any error
+	 */
 	public abstract void run(String... args) throws Exception;
+
+	/**
+	 * Returns the name of this command. Should be all-lowercase, and separated by dashes for words.
+	 * Examples: {@code decompile}, {@code compose-mappings}, {@code fill-class-mappings}
+	 * @return the name of the command
+	 */
+	public abstract String getName();
+
+	/**
+	 * Returns a one-sentence description of this command's function, used in {@link HelpCommand}.
+	 * @return the description
+	 */
+	public abstract String getDescription();
 
 	public static JarIndex loadJar(Path jar) throws IOException {
 		Logger.info("Reading JAR...");
@@ -97,6 +113,12 @@ public abstract class Command {
 		return Enigma.create();
 	}
 
+	/**
+	 * Parses and validates the argument at {@code index}. The argument can then be converted to something more useful via {@link #getReadablePath(String)}, {@link #getWritablePath(String)}, etc.
+	 * @param args the command-line args, provided in {@link #run(String...)}
+	 * @param index the index of the argument
+	 * @return the argument, as a string
+	 */
 	protected String getArg(String[] args, int index) {
 		if (index >= args.length || index >= this.allArguments.size()) {
 			return getArg(args, index, this.allArguments.get(index));

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Command.java
@@ -66,7 +66,10 @@ public abstract class Command {
 
 	private static void appendArguments(StringBuilder builder, List<Argument> arguments) {
 		for (int i = 0; i < arguments.size(); i++) {
-			builder.append(arguments.get(i).getDisplayForm()).append(i == arguments.size() - 1 ? "" : " ");
+			builder.append(arguments.get(i).getDisplayForm());
+			if (i < arguments.size() - 1) {
+				builder.append(" ");
+			}
 		}
 	}
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
@@ -41,8 +41,7 @@ public class ComposeMappingsCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		// todo
-		return null;
+		return "Merges the two mapping trees (left and right) into a common (middle) name set, handling conflicts according to the given \"keep mode\".";
 	}
 
 	public static void run(Path leftFile, Path rightFile, String resultFormat, Path resultFile, String keepMode) throws IOException, MappingParseException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
@@ -16,17 +16,12 @@ import java.nio.file.Path;
 
 public class ComposeMappingsCommand extends Command {
 	public ComposeMappingsCommand() {
-		super("compose-mappings");
-	}
-
-	@Override
-	public String getUsage() {
-		return "<left> <right> <result-format> <result> <keep-mode>";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 5;
+		super("compose-mappings",
+				Argument.LEFT_MAPPINGS.required(),
+				Argument.RIGHT_MAPPINGS.required(),
+				Argument.OUTPUT_MAPPING_FORMAT.required(),
+				Argument.MAPPING_OUTPUT.required(),
+				Argument.KEEP_MODE.required());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
@@ -16,8 +16,7 @@ import java.nio.file.Path;
 
 public class ComposeMappingsCommand extends Command {
 	public ComposeMappingsCommand() {
-		super("compose-mappings",
-				Argument.LEFT_MAPPINGS.required(),
+		super(Argument.LEFT_MAPPINGS.required(),
 				Argument.RIGHT_MAPPINGS.required(),
 				Argument.OUTPUT_MAPPING_FORMAT.required(),
 				Argument.MAPPING_OUTPUT.required(),
@@ -33,6 +32,17 @@ public class ComposeMappingsCommand extends Command {
 		String keepMode = this.getArg(args, 4);
 
 		run(left, right, resultFormat, result, keepMode);
+	}
+
+	@Override
+	public String getName() {
+		return "compose-mappings";
+	}
+
+	@Override
+	public String getDescription() {
+		// todo
+		return null;
 	}
 
 	public static void run(Path leftFile, Path rightFile, String resultFormat, Path resultFile, String keepMode) throws IOException, MappingParseException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ComposeMappingsCommand.java
@@ -26,11 +26,11 @@ public class ComposeMappingsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws IOException, MappingParseException {
-		Path left = getReadablePath(getArg(args, 0, "left", true));
-		Path right = getReadablePath(getArg(args, 1, "right", true));
-		String resultFormat = getArg(args, 2, "result-format", true);
-		Path result = getWritablePath(getArg(args, 3, "result", true));
-		String keepMode = getArg(args, 4, "keep-mode", true);
+		Path left = getReadablePath(this.getArg(args, 0));
+		Path right = getReadablePath(this.getArg(args, 1));
+		String resultFormat = this.getArg(args, 2);
+		Path result = getWritablePath(this.getArg(args, 3));
+		String keepMode = this.getArg(args, 4);
 
 		run(left, right, resultFormat, result, keepMode);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ComposedArgument.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ComposedArgument.java
@@ -1,0 +1,4 @@
+package cuchaz.enigma.command;
+
+public record ComposedArgument(Argument argument, boolean optional) {
+}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ConvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ConvertMappingsCommand.java
@@ -15,17 +15,10 @@ import java.nio.file.Path;
 
 public class ConvertMappingsCommand extends Command {
 	public ConvertMappingsCommand() {
-		super("convert-mappings");
-	}
-
-	@Override
-	public String getUsage() {
-		return "<source> <result-format> <result>";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 3;
+		super("convert-mappings",
+				Argument.INPUT_MAPPINGS.required(),
+				Argument.OUTPUT_MAPPING_FORMAT.required(),
+				Argument.MAPPING_OUTPUT.required());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ConvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ConvertMappingsCommand.java
@@ -23,9 +23,9 @@ public class ConvertMappingsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws IOException, MappingParseException {
-		Path source = getReadablePath(getArg(args, 0, "source", true));
-		String resultFormat = getArg(args, 1, "result-format", true);
-		Path result = getWritablePath(getArg(args, 2, "result", true));
+		Path source = getReadablePath(this.getArg(args, 0));
+		String resultFormat = this.getArg(args, 1);
+		Path result = getWritablePath(this.getArg(args, 2));
 
 		run(source, resultFormat, result);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/ConvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/ConvertMappingsCommand.java
@@ -15,8 +15,7 @@ import java.nio.file.Path;
 
 public class ConvertMappingsCommand extends Command {
 	public ConvertMappingsCommand() {
-		super("convert-mappings",
-				Argument.INPUT_MAPPINGS.required(),
+		super(Argument.INPUT_MAPPINGS.required(),
 				Argument.OUTPUT_MAPPING_FORMAT.required(),
 				Argument.MAPPING_OUTPUT.required());
 	}
@@ -28,6 +27,16 @@ public class ConvertMappingsCommand extends Command {
 		Path result = getWritablePath(this.getArg(args, 2));
 
 		run(source, resultFormat, result);
+	}
+
+	@Override
+	public String getName() {
+		return "convert-mappings";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Converts the provided mappings to a different format.";
 	}
 
 	public static void run(Path source, String resultFormat, Path output) throws MappingParseException, IOException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
@@ -13,17 +13,11 @@ import java.util.Locale;
 
 public class DecompileCommand extends Command {
 	public DecompileCommand() {
-		super("decompile");
-	}
-
-	@Override
-	public String getUsage() {
-		return "<decompiler> <in jar> <out folder> [<mappings file>]";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 3 || length == 4;
+		super("decompile",
+				Argument.DECOMPILER.required(),
+				Argument.INPUT_JAR.required(),
+				Argument.OUTPUT_JAR.required(),
+				Argument.INPUT_MAPPINGS.optional());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
@@ -13,8 +13,7 @@ import java.util.Locale;
 
 public class DecompileCommand extends Command {
 	public DecompileCommand() {
-		super("decompile",
-				Argument.DECOMPILER.required(),
+		super(Argument.DECOMPILER.required(),
 				Argument.INPUT_JAR.required(),
 				Argument.OUTPUT_JAR.required(),
 				Argument.INPUT_MAPPINGS.optional());
@@ -28,6 +27,16 @@ public class DecompileCommand extends Command {
 		Path fileMappings = getReadablePath(this.getArg(args, 3));
 
 		run(decompilerName, fileJarIn, fileJarOut, fileMappings);
+	}
+
+	@Override
+	public String getName() {
+		return "decompile";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Decompiles the provided jar into human-readable code.";
 	}
 
 	public static void run(String decompilerName, Path fileJarIn, Path fileJarOut, Path fileMappings) throws Exception {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DecompileCommand.java
@@ -22,10 +22,10 @@ public class DecompileCommand extends Command {
 
 	@Override
 	public void run(String... args) throws Exception {
-		String decompilerName = getArg(args, 0, "decompiler", true);
-		Path fileJarIn = getReadableFile(getArg(args, 1, "in jar", true)).toPath();
-		Path fileJarOut = getWritableFolder(getArg(args, 2, "out folder", true)).toPath();
-		Path fileMappings = getReadablePath(getArg(args, 3, "mappings file", false));
+		String decompilerName = this.getArg(args, 0);
+		Path fileJarIn = getReadableFile(this.getArg(args, 1)).toPath();
+		Path fileJarOut = getWritableFolder(this.getArg(args, 2)).toPath();
+		Path fileMappings = getReadablePath(this.getArg(args, 3));
 
 		run(decompilerName, fileJarIn, fileJarOut, fileMappings);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DeobfuscateCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DeobfuscateCommand.java
@@ -7,8 +7,7 @@ import java.nio.file.Path;
 
 public class DeobfuscateCommand extends Command {
 	public DeobfuscateCommand() {
-		super("deobfuscate",
-				Argument.INPUT_JAR.required(),
+		super(Argument.INPUT_JAR.required(),
 				Argument.OUTPUT_JAR.required(),
 				Argument.INPUT_MAPPINGS.optional());
 	}
@@ -20,6 +19,16 @@ public class DeobfuscateCommand extends Command {
 		Path fileMappings = getReadablePath(this.getArg(args, 2));
 
 		run(fileJarIn, fileJarOut, fileMappings);
+	}
+
+	@Override
+	public String getName() {
+		return "deobfuscate";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Remaps all names in the jar according to the provided mappings.";
 	}
 
 	public static void run(Path fileJarIn, Path fileJarOut, Path fileMappings) throws Exception {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DeobfuscateCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DeobfuscateCommand.java
@@ -7,17 +7,10 @@ import java.nio.file.Path;
 
 public class DeobfuscateCommand extends Command {
 	public DeobfuscateCommand() {
-		super("deobfuscate");
-	}
-
-	@Override
-	public String getUsage() {
-		return "<in jar> <out jar> [<mappings file>]";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 2 || length == 3;
+		super("deobfuscate",
+				Argument.INPUT_JAR.required(),
+				Argument.OUTPUT_JAR.required(),
+				Argument.INPUT_MAPPINGS.optional());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DeobfuscateCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DeobfuscateCommand.java
@@ -15,9 +15,9 @@ public class DeobfuscateCommand extends Command {
 
 	@Override
 	public void run(String... args) throws Exception {
-		Path fileJarIn = getReadablePath(getArg(args, 0, "in jar", true));
-		Path fileJarOut = getWritableFile(getArg(args, 1, "out jar", true)).toPath();
-		Path fileMappings = getReadablePath(getArg(args, 2, "mappings file", false));
+		Path fileJarIn = getReadablePath(this.getArg(args, 0));
+		Path fileJarOut = getWritableFile(this.getArg(args, 1)).toPath();
+		Path fileMappings = getReadablePath(this.getArg(args, 2));
 
 		run(fileJarIn, fileJarOut, fileMappings);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DropInvalidMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DropInvalidMappingsCommand.java
@@ -15,8 +15,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 public class DropInvalidMappingsCommand extends Command {
 	public DropInvalidMappingsCommand() {
-		super("drop-invalid-mappings",
-				Argument.INPUT_JAR.required(),
+		super(Argument.INPUT_JAR.required(),
 				Argument.INPUT_MAPPINGS.required(),
 				Argument.MAPPING_OUTPUT.optional());
 	}
@@ -29,6 +28,16 @@ public class DropInvalidMappingsCommand extends Command {
 		Path mappingsOut = mappingsOutArg != null && !mappingsOutArg.isEmpty() ? getReadablePath(mappingsOutArg) : mappingsIn;
 
 		run(jarIn, mappingsIn, mappingsOut);
+	}
+
+	@Override
+	public String getName() {
+		return "drop-invalid-mappings";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Removes all invalid mapping entries (entries whose obfuscated name is not found in the jar) from the provided mappings.";
 	}
 
 	public static void run(Path jarIn, Path mappingsIn, Path mappingsOut) throws Exception {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DropInvalidMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DropInvalidMappingsCommand.java
@@ -15,17 +15,10 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 public class DropInvalidMappingsCommand extends Command {
 	public DropInvalidMappingsCommand() {
-		super("dropinvalidmappings");
-	}
-
-	@Override
-	public String getUsage() {
-		return "<in jar> <mappings in> [<mappings out>]";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 3;
+		super("drop-invalid-mappings",
+				Argument.INPUT_JAR.required(),
+				Argument.INPUT_MAPPINGS.required(),
+				Argument.MAPPING_OUTPUT.optional());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/DropInvalidMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/DropInvalidMappingsCommand.java
@@ -23,9 +23,9 @@ public class DropInvalidMappingsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws Exception {
-		Path jarIn = getReadablePath(getArg(args, 0, "in jar", true));
-		Path mappingsIn = getReadablePath(getArg(args, 1, "mappings in", true));
-		String mappingsOutArg = getArg(args, 2, "mappings out", false);
+		Path jarIn = getReadablePath(this.getArg(args, 0));
+		Path mappingsIn = getReadablePath(this.getArg(args, 1));
+		String mappingsOutArg = this.getArg(args, 2);
 		Path mappingsOut = mappingsOutArg != null && !mappingsOutArg.isEmpty() ? getReadablePath(mappingsOutArg) : mappingsIn;
 
 		run(jarIn, mappingsIn, mappingsOut);

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
@@ -19,11 +19,8 @@ import java.nio.file.Path;
 import java.util.List;
 
 public class FillClassMappingsCommand extends Command {
-	public static final String NAME = "fill-class-mappings";
-
 	protected FillClassMappingsCommand() {
-		super(NAME,
-				Argument.INPUT_JAR.required(),
+		super(Argument.INPUT_JAR.required(),
 				Argument.INPUT_MAPPINGS.required(),
 				Argument.MAPPING_OUTPUT.required(),
 				Argument.OUTPUT_MAPPING_FORMAT.required(),
@@ -41,8 +38,19 @@ public class FillClassMappingsCommand extends Command {
 		run(inJar, source, result, resultFormat, fillAll);
 	}
 
+	@Override
+	public String getName() {
+		return "fill-class-mappings";
+	}
+
+	@Override
+	public String getDescription() {
+		// todo
+		return null;
+	}
+
 	public static void run(Path jar, Path source, Path result, String resultFormat, boolean fillAll) throws Exception {
-		boolean debug = shouldDebug(NAME);
+		boolean debug = shouldDebug(new FillClassMappingsCommand().getName());
 		JarIndex jarIndex = loadJar(jar);
 
 		Logger.info("Reading mappings...");

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
@@ -46,7 +46,7 @@ public class FillClassMappingsCommand extends Command {
 	@Override
 	public String getDescription() {
 		// todo
-		return null;
+		return "Adds empty mappings for classes missing in the input file, but whose parent or ancestors, do have names";
 	}
 
 	public static void run(Path jar, Path source, Path result, String resultFormat, boolean fillAll) throws Exception {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
@@ -32,11 +32,11 @@ public class FillClassMappingsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws Exception {
-		Path inJar = getReadablePath(getArg(args, 0, "in-jar", true));
-		Path source = getReadablePath(getArg(args, 1, "source", true));
-		Path result = getWritablePath(getArg(args, 2, "result", true));
-		String resultFormat = getArg(args, 3, "result-format", true);
-		boolean fillAll = Boolean.parseBoolean(getArg(args, 4, "fill-all", false));
+		Path inJar = getReadablePath(this.getArg(args, 0));
+		Path source = getReadablePath(this.getArg(args, 1));
+		Path result = getWritablePath(this.getArg(args, 2));
+		String resultFormat = this.getArg(args, 3);
+		boolean fillAll = Boolean.parseBoolean(this.getArg(args, 4));
 
 		run(inJar, source, result, resultFormat, fillAll);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
@@ -45,7 +45,6 @@ public class FillClassMappingsCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		// todo
 		return "Adds empty mappings for classes missing in the input file, but whose parent or ancestors, do have names";
 	}
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/FillClassMappingsCommand.java
@@ -22,17 +22,12 @@ public class FillClassMappingsCommand extends Command {
 	public static final String NAME = "fill-class-mappings";
 
 	protected FillClassMappingsCommand() {
-		super(NAME);
-	}
-
-	@Override
-	public String getUsage() {
-		return "<in-jar> <source> <result> <result-format> [<fill-all>]";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 4 || length == 5;
+		super(NAME,
+				Argument.INPUT_JAR.required(),
+				Argument.INPUT_MAPPINGS.required(),
+				Argument.MAPPING_OUTPUT.required(),
+				Argument.OUTPUT_MAPPING_FORMAT.required(),
+				Argument.FILL_ALL.optional());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/HelpCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/HelpCommand.java
@@ -1,0 +1,27 @@
+package cuchaz.enigma.command;
+
+import org.tinylog.Logger;
+
+import java.util.Collection;
+
+public class HelpCommand extends Command {
+	protected HelpCommand() {
+		super("help");
+	}
+
+	@Override
+	public void run(String... args) throws Exception {
+		StringBuilder help = new StringBuilder();
+		Collection<Command> commands = Main.getCommands().values();
+
+		help.append("Supported commands:").append("\n");
+		for (Command command : commands) {
+			help.append("- ").append(command.name).append("\n");
+			// todo iota please help!
+			//help.append("\t").append(command.description.append("\n");
+		}
+
+		help.append("Run any command with no arguments in order to see all possible arguments for that command.");
+		Logger.info(help.toString());
+	}
+}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/HelpCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/HelpCommand.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 
 public class HelpCommand extends Command {
 	protected HelpCommand() {
-		super("help");
+		super();
 	}
 
 	@Override
@@ -16,12 +16,21 @@ public class HelpCommand extends Command {
 
 		help.append("Supported commands:").append("\n");
 		for (Command command : commands) {
-			help.append("- ").append(command.name).append("\n");
-			// todo iota please help!
-			//help.append("\t").append(command.description.append("\n");
+			help.append("- ").append(command.getName()).append("\n");
+			help.append("\t").append(command.getDescription()).append("\n");
 		}
 
 		help.append("Run any command with no arguments in order to see all possible arguments for that command.");
 		Logger.info(help.toString());
+	}
+
+	@Override
+	public String getName() {
+		return "help";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Provides a list of commands, along with some short descriptions.";
 	}
 }

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
@@ -32,17 +32,12 @@ public class InsertProposedMappingsCommand extends Command {
 	private static final String NAME = "insert-proposed-mappings";
 
 	public InsertProposedMappingsCommand() {
-		super(NAME);
-	}
-
-	@Override
-	public String getUsage() {
-		return "<in jar> <source> <result> <result-format> [<profile>]";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 4 || length == 5;
+		super(NAME,
+				Argument.INPUT_JAR.required(),
+				Argument.INPUT_MAPPINGS.required(),
+				Argument.MAPPING_OUTPUT.required(),
+				Argument.OUTPUT_MAPPING_FORMAT.required(),
+				Argument.ENIGMA_PROFILE.optional());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
@@ -29,11 +29,8 @@ import java.nio.file.Path;
 import javax.annotation.Nullable;
 
 public class InsertProposedMappingsCommand extends Command {
-	private static final String NAME = "insert-proposed-mappings";
-
 	public InsertProposedMappingsCommand() {
-		super(NAME,
-				Argument.INPUT_JAR.required(),
+		super(Argument.INPUT_JAR.required(),
 				Argument.INPUT_MAPPINGS.required(),
 				Argument.MAPPING_OUTPUT.required(),
 				Argument.OUTPUT_MAPPING_FORMAT.required(),
@@ -48,10 +45,20 @@ public class InsertProposedMappingsCommand extends Command {
 		String resultFormat = this.getArg(args, 3);
 		Path profilePath = getReadablePath(this.getArg(args, 4));
 
-		run(inJar, source, output, resultFormat, profilePath, null);
+		this.run(inJar, source, output, resultFormat, profilePath, null);
 	}
 
-	public static void run(Path inJar, Path source, Path output, String resultFormat, @Nullable Path profilePath, @Nullable Iterable<EnigmaPlugin> plugins) throws Exception {
+	@Override
+	public String getName() {
+		return "insert-proposed-mappings";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Adds all mappings proposed by the provided plugins into the given mappings.";
+	}
+
+	public void run(Path inJar, Path source, Path output, String resultFormat, @Nullable Path profilePath, @Nullable Iterable<EnigmaPlugin> plugins) throws Exception {
 		EnigmaProfile profile = EnigmaProfile.read(profilePath);
 		Enigma enigma = createEnigma(profile, plugins);
 
@@ -59,7 +66,7 @@ public class InsertProposedMappingsCommand extends Command {
 	}
 
 	public static void run(Path inJar, Path source, Path output, String resultFormat, Enigma enigma) throws Exception {
-		boolean debug = shouldDebug(NAME);
+		boolean debug = shouldDebug(new InsertProposedMappingsCommand().getName());
 		NameProposalService[] nameProposalServices = enigma.getServices().get(NameProposalService.TYPE).toArray(new NameProposalService[0]);
 		if (nameProposalServices.length == 0) {
 			Logger.error("No name proposal service found");

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
@@ -42,11 +42,11 @@ public class InsertProposedMappingsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws Exception {
-		Path inJar = getReadablePath(getArg(args, 0, "in jar", true));
-		Path source = getReadablePath(getArg(args, 1, "source", true));
-		Path output = getWritablePath(getArg(args, 2, "result", true));
-		String resultFormat = getArg(args, 3, "result-format", true);
-		Path profilePath = getReadablePath(getArg(args, 4, "profile", false));
+		Path inJar = getReadablePath(this.getArg(args, 0));
+		Path source = getReadablePath(this.getArg(args, 1));
+		Path output = getWritablePath(this.getArg(args, 2));
+		String resultFormat = this.getArg(args, 3);
+		Path profilePath = getReadablePath(this.getArg(args, 4));
 
 		run(inJar, source, output, resultFormat, profilePath, null);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InsertProposedMappingsCommand.java
@@ -45,7 +45,7 @@ public class InsertProposedMappingsCommand extends Command {
 		String resultFormat = this.getArg(args, 3);
 		Path profilePath = getReadablePath(this.getArg(args, 4));
 
-		this.run(inJar, source, output, resultFormat, profilePath, null);
+		run(inJar, source, output, resultFormat, profilePath, null);
 	}
 
 	@Override
@@ -55,10 +55,10 @@ public class InsertProposedMappingsCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		return "Adds all mappings proposed by the provided plugins into the given mappings.";
+		return "Adds all mappings proposed by the plugins on the classpath and declared in the profile into the given mappings.";
 	}
 
-	public void run(Path inJar, Path source, Path output, String resultFormat, @Nullable Path profilePath, @Nullable Iterable<EnigmaPlugin> plugins) throws Exception {
+	public static void run(Path inJar, Path source, Path output, String resultFormat, @Nullable Path profilePath, @Nullable Iterable<EnigmaPlugin> plugins) throws Exception {
 		EnigmaProfile profile = EnigmaProfile.read(profilePath);
 		Enigma enigma = createEnigma(profile, plugins);
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
@@ -15,8 +15,7 @@ import java.nio.file.Path;
 
 public class InvertMappingsCommand extends Command {
 	public InvertMappingsCommand() {
-		super("invert-mappings",
-				Argument.INPUT_MAPPINGS.required(),
+		super(Argument.INPUT_MAPPINGS.required(),
 				Argument.OUTPUT_MAPPING_FORMAT.required(),
 				Argument.OUTPUT_FOLDER.required());
 	}
@@ -28,6 +27,17 @@ public class InvertMappingsCommand extends Command {
 		Path result = getWritablePath(this.getArg(args, 2));
 
 		run(source, resultFormat, result);
+	}
+
+	@Override
+	public String getName() {
+		return "invert-mappings";
+	}
+
+	@Override
+	public String getDescription() {
+		// todo
+		return null;
 	}
 
 	public static void run(Path sourceFile, String resultFormat, Path resultFile) throws MappingParseException, IOException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
@@ -15,17 +15,10 @@ import java.nio.file.Path;
 
 public class InvertMappingsCommand extends Command {
 	public InvertMappingsCommand() {
-		super("invert-mappings");
-	}
-
-	@Override
-	public String getUsage() {
-		return "<source> <result-format> <result>";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 4;
+		super("invert-mappings",
+				Argument.INPUT_MAPPINGS.required(),
+				Argument.OUTPUT_MAPPING_FORMAT.required(),
+				Argument.OUTPUT_FOLDER.required());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
@@ -36,8 +36,7 @@ public class InvertMappingsCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		// todo
-		return "Flips the source names with the destination names, ie. 'class a -> Example' becomes 'class Example -> a'";
+		return "Flips the source names with the destination names, ie. 'class a -> Example' becomes 'class Example -> a'.";
 	}
 
 	public static void run(Path sourceFile, String resultFormat, Path resultFile) throws MappingParseException, IOException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
@@ -37,7 +37,7 @@ public class InvertMappingsCommand extends Command {
 	@Override
 	public String getDescription() {
 		// todo
-		return null;
+		return "Flips the source names with the destination names, ie. 'class a -> Example' becomes 'class Example -> a'";
 	}
 
 	public static void run(Path sourceFile, String resultFormat, Path resultFile) throws MappingParseException, IOException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/InvertMappingsCommand.java
@@ -23,9 +23,9 @@ public class InvertMappingsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws IOException, MappingParseException {
-		Path source = getReadablePath(getArg(args, 0, "source", true));
-		String resultFormat = getArg(args, 1, "result-format", true);
-		Path result = getWritablePath(getArg(args, 2, "result", true));
+		Path source = getReadablePath(this.getArg(args, 0));
+		String resultFormat = this.getArg(args, 1);
+		Path result = getWritablePath(this.getArg(args, 2));
 
 		run(source, resultFormat, result);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
@@ -39,7 +39,7 @@ public class Main {
 		} catch (CommandHelpException ex) {
 			Logger.error(ex);
 			logEnigmaInfo();
-			Logger.info("Command {} has encountered an error! Usage:", ex.command.name);
+			Logger.info("Command {} has encountered an error! Usage:", ex.command.getName());
 			StringBuilder help = new StringBuilder();
 			appendHelp(ex.command, help);
 			Logger.info(help.toString());
@@ -70,7 +70,7 @@ public class Main {
 	}
 
 	private static void appendHelp(Command command, StringBuilder builder) {
-		builder.append(String.format("\t\t%s %s", command.name, command.getUsage())).append("\n");
+		builder.append(String.format("\t\t%s %s", command.getName(), command.getUsage())).append("\n");
 
 		if (!command.requiredArguments.isEmpty()) {
 			builder.append("Arguments:").append("\n");
@@ -98,9 +98,9 @@ public class Main {
 	}
 
 	private static void register(Command command) {
-		Command old = COMMANDS.put(command.name, command);
+		Command old = COMMANDS.put(command.getName(), command);
 		if (old != null) {
-			Logger.warn("Command {} with name {} has been substituted by {}", old, command.name, command);
+			Logger.warn("Command {} with name {} has been substituted by {}", old, command.getName(), command);
 		}
 	}
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
@@ -51,6 +51,10 @@ public class Main {
 		}
 	}
 
+	public static Map<String, Command> getCommands() {
+		return COMMANDS;
+	}
+
 	private static void printHelp() {
 		logEnigmaInfo();
 
@@ -115,6 +119,7 @@ public class Main {
 		register(new InsertProposedMappingsCommand());
 		register(new DropInvalidMappingsCommand());
 		register(new FillClassMappingsCommand());
+		register(new HelpCommand());
 	}
 
 	private static final class CommandHelpException extends IllegalArgumentException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/Main.java
@@ -24,7 +24,7 @@ public class Main {
 				throw new IllegalArgumentException("Command not recognized: " + command);
 			}
 
-			if (!cmd.isValidArgument(args.length - 1)) {
+			if (!cmd.checkArgumentCount(args.length - 1)) {
 				throw new CommandHelpException(cmd);
 			}
 
@@ -40,7 +40,9 @@ public class Main {
 			Logger.error(ex);
 			logEnigmaInfo();
 			Logger.info("Command {} has encountered an error! Usage:", ex.command.name);
-			printHelp(ex.command);
+			StringBuilder help = new StringBuilder();
+			appendHelp(ex.command, help);
+			Logger.info(help.toString());
 			System.exit(1);
 		} catch (IllegalArgumentException ex) {
 			Logger.error(ex);
@@ -51,18 +53,44 @@ public class Main {
 
 	private static void printHelp() {
 		logEnigmaInfo();
-		Logger.info("""
+
+		StringBuilder help = new StringBuilder();
+		help.append("""
 				Usage:
 				\tjava -cp enigma.jar cuchaz.enigma.command.CommandMain <command> <args>
 				\twhere <command> is one of:""");
 
 		for (Command command : COMMANDS.values()) {
-			printHelp(command);
+			appendHelp(command, help);
 		}
 	}
 
-	private static void printHelp(Command command) {
-		Logger.info("\t\t{} {}", command.name, command.getUsage());
+	private static void appendHelp(Command command, StringBuilder builder) {
+		builder.append(String.format("\t\t%s %s", command.name, command.getUsage())).append("\n");
+
+		if (!command.requiredArguments.isEmpty()) {
+			builder.append("Arguments:").append("\n");
+			int argIndex = 0;
+			for (int j = 0; j < command.requiredArguments.size(); j++) {
+				Argument argument = command.requiredArguments.get(j);
+				appendHelp(argument, argIndex, builder);
+				argIndex++;
+			}
+
+			if (!command.optionalArguments.isEmpty()) {
+				builder.append("\n").append("Optional arguments:").append("\n");
+				for (int i = 0; i < command.optionalArguments.size(); i++) {
+					Argument argument = command.optionalArguments.get(i);
+					appendHelp(argument, argIndex, builder);
+					argIndex++;
+				}
+			}
+		}
+	}
+
+	private static void appendHelp(Argument argument, int index, StringBuilder builder) {
+		builder.append(String.format("Argument %s: %s", index, argument.getDisplayForm())).append("\n");
+		builder.append(argument.getExplanation()).append("\n");
 	}
 
 	private static void register(Command command) {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -34,10 +34,10 @@ public class MapSpecializedMethodsCommand extends Command {
 
 	@Override
 	public void run(String... args) throws IOException, MappingParseException {
-		Path jar = getReadablePath(getArg(args, 0, "jar", true));
-		Path source = getReadablePath(getArg(args, 1, "source", true));
-		String resultFormat = getArg(args, 2, "result-format", true);
-		Path result = getWritablePath(getArg(args, 3, "result", true));
+		Path jar = getReadablePath(this.getArg(args, 0));
+		Path source = getReadablePath(this.getArg(args, 1));
+		String resultFormat = this.getArg(args, 2);
+		Path result = getWritablePath(this.getArg(args, 3));
 
 		run(jar, source, resultFormat, result);
 	}

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -25,17 +25,11 @@ public class MapSpecializedMethodsCommand extends Command {
 	private static final String NAME = "map-specialized-methods";
 
 	public MapSpecializedMethodsCommand() {
-		super(NAME);
-	}
-
-	@Override
-	public String getUsage() {
-		return "<jar> <source> <result-format> <result>";
-	}
-
-	@Override
-	public boolean isValidArgument(int length) {
-		return length == 4;
+		super(NAME,
+				Argument.INPUT_JAR.required(),
+				Argument.INPUT_MAPPINGS.required(),
+				Argument.OUTPUT_MAPPING_FORMAT.required(),
+				Argument.MAPPING_OUTPUT.required());
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -22,11 +22,8 @@ import java.nio.file.Path;
 import java.util.Map;
 
 public class MapSpecializedMethodsCommand extends Command {
-	private static final String NAME = "map-specialized-methods";
-
 	public MapSpecializedMethodsCommand() {
-		super(NAME,
-				Argument.INPUT_JAR.required(),
+		super(Argument.INPUT_JAR.required(),
 				Argument.INPUT_MAPPINGS.required(),
 				Argument.OUTPUT_MAPPING_FORMAT.required(),
 				Argument.MAPPING_OUTPUT.required());
@@ -42,8 +39,19 @@ public class MapSpecializedMethodsCommand extends Command {
 		run(jar, source, resultFormat, result);
 	}
 
+	@Override
+	public String getName() {
+		return "map-specialized-methods";
+	}
+
+	@Override
+	public String getDescription() {
+		// todo
+		return null;
+	}
+
 	public static void run(Path jar, Path sourcePath, String resultFormat, Path output) throws IOException, MappingParseException {
-		boolean debug = shouldDebug(NAME);
+		boolean debug = shouldDebug(new MapSpecializedMethodsCommand().getName());
 		JarIndex jarIndex = loadJar(jar);
 
 		MappingSaveParameters saveParameters = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF);

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -47,7 +47,7 @@ public class MapSpecializedMethodsCommand extends Command {
 	@Override
 	public String getDescription() {
 		// todo
-		return null;
+		return "Adds names for specialized methods from their corresponding bridge method";
 	}
 
 	public static void run(Path jar, Path sourcePath, String resultFormat, Path output) throws IOException, MappingParseException {

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/MapSpecializedMethodsCommand.java
@@ -46,7 +46,6 @@ public class MapSpecializedMethodsCommand extends Command {
 
 	@Override
 	public String getDescription() {
-		// todo
 		return "Adds names for specialized methods from their corresponding bridge method";
 	}
 

--- a/enigma-cli/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
+++ b/enigma-cli/src/main/java/cuchaz/enigma/command/MappingCommandsUtil.java
@@ -2,20 +2,14 @@ package cuchaz.enigma.command;
 
 import cuchaz.enigma.translation.mapping.serde.MappingFormat;
 import cuchaz.enigma.translation.mapping.serde.MappingsWriter;
-import cuchaz.enigma.translation.mapping.serde.enigma.EnigmaMappingsWriter;
 import cuchaz.enigma.translation.mapping.serde.tinyv2.TinyV2Writer;
 
 public final class MappingCommandsUtil {
 	private MappingCommandsUtil() {
 	}
 
-	// todo: ew
 	public static MappingsWriter getWriter(String type) {
-		if (type.equals("enigma")) {
-			return EnigmaMappingsWriter.DIRECTORY;
-		}
-
-		if (type.startsWith("tinyv2:") || type.startsWith("tiny_v2:")) {
+		if (type.toLowerCase().startsWith("tinyv2:") || type.toLowerCase().startsWith("tiny_v2:")) {
 			String[] split = type.split(":");
 
 			if (split.length != 3) {


### PR DESCRIPTION
TODO
- [x] improve arg parsing

CHANGES:
- adds a big enum for all possible args
- greatly improves help printed on command fail:
![image](https://github.com/QuiltMC/enigma/assets/66223394/299d3daf-6ece-4cf6-874f-724aae954f6b)
- adds a "help" command
![image](https://github.com/QuiltMC/enigma/assets/66223394/c3dd8da2-0758-475c-8a42-d3e49f42fc8b)
- improves quite a bit of code using the new enum
- edits all command names to use `kebab-case`