### PR TITLE
Fix regex for renaming package with a capital letter

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/ClassSelectorPopupMenu.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/elements/ClassSelectorPopupMenu.java
@@ -107,7 +107,7 @@ public class ClassSelectorPopupMenu {
 
 	public CompletableFuture<Void> renamePackage(String path, String input) {
 		// validate input
-		if (input == null || !input.matches("[a-z0-9_/]+") || input.isBlank() || input.startsWith("/") || input.endsWith("/")) {
+		if (input == null || !input.matches("[a-zA-Z0-9_/]+") || input.isBlank() || input.startsWith("/") || input.endsWith("/")) {
 			this.gui.getNotificationManager().notify(Message.INVALID_PACKAGE_NAME);
 			return CompletableFuture.supplyAsync(() -> null);
 		}


### PR DESCRIPTION
The current input check does not account for capitalization in the package path. It will fail whenever it does.
It's possible packages could have capital letters so I'm making this PR to fix that.

Before:
![M6gEzZEBtC](https://github.com/QuiltMC/enigma/assets/124226059/302b6634-7641-424d-a8a9-afbf17ec0847)

After:
![uGcete0vrj](https://github.com/QuiltMC/enigma/assets/124226059/8d9080c9-f535-4da5-b462-48d6b9144b70)
