### PR TITLE
better highlight box sizes: fix overlap

### DIFF
--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
@@ -31,8 +31,8 @@ public class BoxHighlightPainter implements Highlighter.HighlightPainter {
 			Rectangle2D.union(startRect, endRect, bounds);
 
 			// adjust the box so it looks nice
-			bounds.x -= 2;
-			bounds.width += 2;
+			bounds.x -= 1;
+			bounds.width += 1;
 			bounds.y += 1;
 			bounds.height -= 2;
 

--- a/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
+++ b/enigma-swing/src/main/java/cuchaz/enigma/gui/highlight/BoxHighlightPainter.java
@@ -31,7 +31,7 @@ public class BoxHighlightPainter implements Highlighter.HighlightPainter {
 			Rectangle2D.union(startRect, endRect, bounds);
 
 			// adjust the box so it looks nice
-			bounds.x -= 1;
+			bounds.x -= 2;
 			bounds.width += 1;
 			bounds.y += 1;
 			bounds.height -= 2;


### PR DESCRIPTION
this looks better than the old one :+1: 
![image](https://github.com/QuiltMC/enigma/assets/66223394/237faa24-6b4c-4ff0-898a-9b3c84476697)
