### PR TITLE
fix index issues

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/PackageRenamer.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/PackageRenamer.java
@@ -242,7 +242,8 @@ public class PackageRenamer {
 				}
 
 				String newName = String.join("/", split);
-				this.gui.getController().applyChange(new ValidationContext(this.gui.getNotificationManager()), EntryChange.modify(classNode.getObfEntry()).withDeobfName(newName), false);
+				// ignore warnings, we don't want to bother the user with every individual package created
+				this.gui.getController().applyChange(new ValidationContext(this.gui.getNotificationManager(), false), EntryChange.modify(classNode.getObfEntry()).withDeobfName(newName), false);
 			});
 		} else if (node instanceof ClassSelectorPackageNode packageNode) {
 			String packageName = packageNode.getPackageName().substring(packageNode.getPackageName().lastIndexOf("/") + 1);

--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/JarIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/JarIndex.java
@@ -22,15 +22,15 @@ import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.ParentedEntry;
 import org.quiltmc.enigma.util.I18n;
 
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 public class JarIndex implements JarIndexer {
 	private final Set<String> indexedClasses = new HashSet<>();
-	private final Map<Class<? extends JarIndexer>, JarIndexer> indexers = new HashMap<>();
+	private final Map<Class<? extends JarIndexer>, JarIndexer> indexers = new LinkedHashMap<>();
 	private final IndexEntryResolver entryResolver;
 
 	private final Multimap<String, MethodDefEntry> methodImplementations = HashMultimap.create();
@@ -40,6 +40,7 @@ public class JarIndex implements JarIndexer {
 
 	/**
 	 * Creates a new empty index with all provided indexers.
+	 * Indexers will be run in the order they're passed to this constructor.
 	 * @param indexers the indexers to use
 	 */
 	public JarIndex(JarIndexer... indexers) {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/mapping/MappingsIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/mapping/MappingsIndex.java
@@ -12,8 +12,8 @@ import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.util.I18n;
 import org.quiltmc.enigma.util.Pair;
 
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -21,13 +21,14 @@ import java.util.Set;
  * A consolidated {@link MappingsIndexer} that can be configured to use as many separate indexers as you like.
  */
 public class MappingsIndex implements MappingsIndexer {
-	private final Map<Class<? extends MappingsIndexer>, MappingsIndexer> indexers = new HashMap<>();
+	private final Map<Class<? extends MappingsIndexer>, MappingsIndexer> indexers = new LinkedHashMap<>();
 
 	private ProgressListener progress;
 	private int work;
 
 	/**
 	 * Creates a new empty index with all provided indexers.
+	 * Indexers will be run in the order they're passed to this constructor.
 	 * @param indexers the indexers to use
 	 */
 	public MappingsIndex(MappingsIndexer... indexers) {

--- a/enigma/src/main/java/org/quiltmc/enigma/util/validation/ValidationContext.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/util/validation/ValidationContext.java
@@ -11,14 +11,25 @@ import java.util.Objects;
  */
 public class ValidationContext {
 	private final List<ParameterizedMessage> messages = new ArrayList<>();
+	private final boolean verifyWarnings;
 	private Notifier notifier;
+
+	/**
+	 * Creates a new validation context with no messages. Will ask the user before proceeding with warnings.
+	 * @param notifier the notifier to pass new messages into, defaults to {@link PrintNotifier#INSTANCE} if null
+	 */
+	public ValidationContext(Notifier notifier) {
+		this(notifier, true);
+	}
 
 	/**
 	 * Creates a new validation context with no messages.
 	 * @param notifier the notifier to pass new messages into, defaults to {@link PrintNotifier#INSTANCE} if null
+	 * @param verifyWarnings whether to ask the user whether to proceed on warnings. If {@code false}, all warnings will be ignored
 	 */
-	public ValidationContext(Notifier notifier) {
+	public ValidationContext(Notifier notifier, boolean verifyWarnings) {
 		this.notifier = Objects.requireNonNullElse(notifier, PrintNotifier.INSTANCE);
+		this.verifyWarnings = verifyWarnings;
 	}
 
 	/**
@@ -55,11 +66,13 @@ public class ValidationContext {
 	public boolean canProceed() {
 		List<ParameterizedMessage> messagesCopy = new ArrayList<>(this.messages);
 
-		for (ParameterizedMessage m : messagesCopy) {
-			if (m.getType() == Message.Type.WARNING) {
-				this.messages.remove(m);
-				if (!this.notifier.verifyWarning(m)) {
-					return false;
+		if (this.verifyWarnings) {
+			for (ParameterizedMessage m : messagesCopy) {
+				if (m.getType() == Message.Type.WARNING) {
+					this.messages.remove(m);
+					if (!this.notifier.verifyWarning(m)) {
+						return false;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- fix wrong order of indexers being run
  - changes indexer map to an ordered `LinkedHashMap`
- fix renaming packages creating warnings
  - adds a `verifyWarnings` parameter to each `ValidationContext`, package renaming sets this to false