### PR TITLE
Allow using json lists for service args

### DIFF
--- a/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
@@ -11,6 +11,7 @@ import org.quiltmc.enigma.api.class_provider.ClassProvider;
 import org.quiltmc.enigma.api.class_provider.CombiningClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
 import org.quiltmc.enigma.api.class_provider.ObfuscationFixClassProvider;
+import org.quiltmc.enigma.util.Either;
 import org.quiltmc.enigma.util.I18n;
 import org.quiltmc.enigma.util.Utils;
 import com.google.common.base.Preconditions;
@@ -135,7 +136,7 @@ public class Enigma {
 		private <T extends EnigmaService> EnigmaServiceContext<T> getServiceContext(EnigmaProfile.Service serviceProfile) {
 			return new EnigmaServiceContext<>() {
 				@Override
-				public Optional<String> getArgument(String key) {
+				public Optional<Either<String, List<String>>> getArgument(String key) {
 					return serviceProfile.getArgument(key);
 				}
 

--- a/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProfile.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProfile.java
@@ -13,6 +13,7 @@ import com.google.gson.reflect.TypeToken;
 import org.quiltmc.enigma.api.service.EnigmaServiceType;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingFileNameFormat;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
+import org.quiltmc.enigma.util.Either;
 import org.tinylog.Logger;
 
 import javax.annotation.Nullable;
@@ -118,9 +119,9 @@ public final class EnigmaProfile {
 
 	public static class Service {
 		private final String id;
-		private final Map<String, String> args;
+		private final Map<String, Either<String, List<String>>> args;
 
-		Service(String id, Map<String, String> args) {
+		Service(String id, Map<String, Either<String, List<String>>> args) {
 			this.id = id;
 			this.args = args;
 		}
@@ -129,7 +130,7 @@ public final class EnigmaProfile {
 			return this.id.equals(id);
 		}
 
-		public Optional<String> getArgument(String key) {
+		public Optional<Either<String, List<String>>> getArgument(String key) {
 			return this.args != null ? Optional.ofNullable(this.args.get(key)) : Optional.empty();
 		}
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/service/EnigmaServiceContext.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/service/EnigmaServiceContext.java
@@ -1,6 +1,9 @@
 package org.quiltmc.enigma.api.service;
 
+import org.quiltmc.enigma.util.Either;
+
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
 public interface EnigmaServiceContext<T extends EnigmaService> {
@@ -8,7 +11,15 @@ public interface EnigmaServiceContext<T extends EnigmaService> {
 		return key -> Optional.empty();
 	}
 
-	Optional<String> getArgument(String key);
+	Optional<Either<String, List<String>>> getArgument(String key);
+
+	default Optional<String> getSingleArgument(String key) {
+		return this.getArgument(key).flatMap(e -> e.left());
+	}
+
+	default Optional<List<String>> getMultipleArguments(String key) {
+		return this.getArgument(key).flatMap(e -> e.right());
+	}
 
 	default Path getPath(String path) {
 		return Path.of(path);

--- a/enigma/src/main/java/org/quiltmc/enigma/api/source/Decompiler.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/source/Decompiler.java
@@ -1,7 +1,8 @@
 package org.quiltmc.enigma.api.source;
 
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.annotation.Nullable;
 
 public interface Decompiler {
 	default Source getUndocumentedSource(String className) {

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeDecompiler.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeDecompiler.java
@@ -5,9 +5,9 @@ import org.quiltmc.enigma.api.source.Decompiler;
 import org.quiltmc.enigma.api.source.Source;
 import org.quiltmc.enigma.api.source.SourceSettings;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.objectweb.asm.tree.ClassNode;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/CfrDecompiler.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/CfrDecompiler.java
@@ -12,9 +12,9 @@ import org.benf.cfr.reader.bytecode.analysis.parse.utils.Pair;
 import org.benf.cfr.reader.util.AnalysisType;
 import org.benf.cfr.reader.util.getopt.Options;
 import org.benf.cfr.reader.util.getopt.OptionsImpl;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.objectweb.asm.tree.ClassNode;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
 

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/CfrSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/CfrSource.java
@@ -15,7 +15,8 @@ import org.benf.cfr.reader.util.CannotLoadClassException;
 import org.benf.cfr.reader.util.collections.ListFactory;
 import org.benf.cfr.reader.util.getopt.Options;
 import org.benf.cfr.reader.util.getopt.OptionsImpl;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.annotation.Nullable;
 
 public class CfrSource implements Source {
 	private final String className;

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/EnigmaDumper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/EnigmaDumper.java
@@ -29,8 +29,8 @@ import org.benf.cfr.reader.util.output.IllegalIdentifierDump;
 import org.benf.cfr.reader.util.output.MovableDumperContext;
 import org.benf.cfr.reader.util.output.StringStreamDumper;
 import org.benf.cfr.reader.util.output.TypeContext;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/procyon/ProcyonDecompiler.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/procyon/ProcyonDecompiler.java
@@ -25,8 +25,9 @@ import org.quiltmc.enigma.impl.source.procyon.transformer.RemoveObjectCasts;
 import org.quiltmc.enigma.impl.source.procyon.transformer.VarargsFixer;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.util.AsmUtil;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.objectweb.asm.tree.ClassNode;
+
+import javax.annotation.Nullable;
 
 public class ProcyonDecompiler implements Decompiler {
 	private final SourceSettings settings;

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/vineflower/VineflowerDecompiler.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/vineflower/VineflowerDecompiler.java
@@ -5,7 +5,8 @@ import org.quiltmc.enigma.api.source.Decompiler;
 import org.quiltmc.enigma.api.source.Source;
 import org.quiltmc.enigma.api.source.SourceSettings;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.annotation.Nullable;
 
 public class VineflowerDecompiler implements Decompiler {
 	private final ClassProvider classProvider;

--- a/enigma/src/main/java/org/quiltmc/enigma/util/Either.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/util/Either.java
@@ -1,0 +1,212 @@
+package org.quiltmc.enigma.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+@JsonAdapter(Either.CustomTypeAdapterFactory.class)
+public abstract class Either<L, R> {
+	public abstract <T> T map(Function<L, ? extends T> l, Function<R, ? extends T> r);
+
+	public <A, B> Either<? extends A, ? extends B> flatMap(Function<L, Either<? extends A, ? extends B>> l, Function<R, Either<? extends A, ? extends B>> r) {
+		return this.map(l, r);
+	}
+
+	public abstract <A, B> Either<A, B> mapBoth(Function<L, ? extends A> l, Function<R, ? extends B> r);
+
+	public <T> Either<T, R> mapLeft(Function<L, ? extends T> l) {
+		return this.map(v -> left(l.apply(v)), Either::right);
+	}
+
+	public <T> Either<L, T> mapRight(Function<R, ? extends T> r) {
+		return this.map(Either::left, v -> right(r.apply(v)));
+	}
+
+	public abstract Either<L, R> ifLeft(Consumer<? super L> consumer);
+
+	public abstract Either<L, R> ifRight(Consumer<? super R> consumer);
+
+	public abstract boolean isLeft();
+
+	public abstract boolean isRight();
+
+	public abstract Optional<L> left();
+
+	public abstract Optional<R> right();
+
+	public L leftOrThrow() {
+		return this.left().orElseThrow();
+	}
+
+	public R rightOrThrow() {
+		return this.right().orElseThrow();
+	}
+
+	public static <L, R> Either<L, R> left(L value) {
+		return new Left<>(value);
+	}
+
+	public static <L, R> Either<L, R> right(R value) {
+		return new Right<>(value);
+	}
+
+	private static final class Left<L, R> extends Either<L, R> {
+		private final L value;
+
+		private Left(L value) {
+			this.value = value;
+		}
+
+		@Override
+		public <T> T map(Function<L, ? extends T> l, Function<R, ? extends T> r) {
+			return l.apply(this.value);
+		}
+
+		@Override
+		public <A, B> Either<A, B> mapBoth(Function<L, ? extends A> l, Function<R, ? extends B> r) {
+			return new Left<>(l.apply(this.value));
+		}
+
+		@Override
+		public Either<L, R> ifLeft(Consumer<? super L> consumer) {
+			consumer.accept(this.value);
+			return this;
+		}
+
+		@Override
+		public Either<L, R> ifRight(Consumer<? super R> consumer) {
+			return this;
+		}
+
+		@Override
+		public boolean isLeft() {
+			return true;
+		}
+
+		@Override
+		public boolean isRight() {
+			return false;
+		}
+
+		@Override
+		public Optional<L> left() {
+			return Optional.of(this.value);
+		}
+
+		@Override
+		public Optional<R> right() {
+			return Optional.empty();
+		}
+	}
+
+	private static final class Right<L, R> extends Either<L, R> {
+		private final R value;
+
+		private Right(R value) {
+			this.value = value;
+		}
+
+		@Override
+		public <T> T map(Function<L, ? extends T> l, Function<R, ? extends T> r) {
+			return r.apply(this.value);
+		}
+
+		@Override
+		public <A, B> Either<A, B> mapBoth(Function<L, ? extends A> l, Function<R, ? extends B> r) {
+			return new Right<>(r.apply(this.value));
+		}
+
+		@Override
+		public Either<L, R> ifLeft(Consumer<? super L> consumer) {
+			return this;
+		}
+
+		@Override
+		public Either<L, R> ifRight(Consumer<? super R> consumer) {
+			consumer.accept(this.value);
+			return this;
+		}
+
+		@Override
+		public boolean isLeft() {
+			return false;
+		}
+
+		@Override
+		public boolean isRight() {
+			return true;
+		}
+
+		@Override
+		public Optional<L> left() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<R> right() {
+			return Optional.of(this.value);
+		}
+	}
+
+	static final class CustomTypeAdapterFactory implements TypeAdapterFactory {
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+			Type type = typeToken.getType();
+			if (typeToken.getRawType() != Either.class || !(type instanceof ParameterizedType parameterizedType)) {
+				return null;
+			}
+
+			Type leftType = parameterizedType.getActualTypeArguments()[0];
+			Type rightType = parameterizedType.getActualTypeArguments()[1];
+			TypeAdapter<?> leftAdapter = gson.getAdapter(TypeToken.get(leftType));
+			TypeAdapter<?> rightAdapter = gson.getAdapter(TypeToken.get(rightType));
+
+			return (TypeAdapter<T>) this.newEitherAdapter(leftAdapter, rightAdapter);
+		}
+
+		private <L, R> TypeAdapter<Either<L, R>> newEitherAdapter(TypeAdapter<L> leftAdapter, TypeAdapter<R> rightAdapter) {
+			return new TypeAdapter<>() {
+				@Override
+				public void write(JsonWriter out, Either<L, R> value) throws IOException {
+					if (value.isLeft()) {
+						leftAdapter.write(out, value.leftOrThrow());
+					} else {
+						rightAdapter.write(out, value.rightOrThrow());
+					}
+				}
+
+				@Override
+				public Either<L, R> read(JsonReader in) throws IOException {
+					try {
+						L left = leftAdapter.read(in);
+						return left(left);
+					} catch (JsonParseException | IllegalStateException ignored) {
+						// ignore
+					}
+
+					try {
+						R right = rightAdapter.read(in);
+						return right(right);
+					} catch (JsonParseException | IllegalStateException ignored) {
+						// ignore
+					}
+
+					return null;
+				}
+			};
+		}
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/EnigmaProfileTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/EnigmaProfileTest.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 public class EnigmaProfileTest {
 	@Test
 	public void testParse() {
-		//noinspection CheckStyle
 		Reader r = new StringReader("""
 				{
 					"mapping_save_parameters": {
@@ -51,8 +50,7 @@ public class EnigmaProfileTest {
 							}
 						]
 					}
-				}
-				""");
+				}""");
 		EnigmaProfile profile = EnigmaProfile.parse(r);
 
 		Assertions.assertEquals(MappingFileNameFormat.BY_DEOBF, profile.getMappingSaveParameters().fileNameFormat());

--- a/enigma/src/test/java/org/quiltmc/enigma/EnigmaProfileTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/EnigmaProfileTest.java
@@ -1,0 +1,78 @@
+package org.quiltmc.enigma;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.enigma.api.EnigmaProfile;
+import org.quiltmc.enigma.api.service.JarIndexerService;
+import org.quiltmc.enigma.api.service.NameProposalService;
+import org.quiltmc.enigma.api.source.DecompilerService;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingFileNameFormat;
+import org.quiltmc.enigma.util.Either;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.List;
+import java.util.Optional;
+
+public class EnigmaProfileTest {
+	@Test
+	public void testParse() {
+		//noinspection CheckStyle
+		Reader r = new StringReader("""
+				{
+					"mapping_save_parameters": {
+						"file_name_format": "by_deobf"
+					},
+					"services": {
+						"decompiler": {
+							"id": "enigma:vineflower"
+						},
+						"jar_indexer": {
+							"id": "enigma:dummy",
+							"args": {
+								"abc": "hello world",
+								"foo": ["lorem", "ipsum", "dolor", "sit", "amet"]
+							}
+						},
+						"name_proposal": [
+							{
+								"id": "enigma:enum_name_proposer"
+							},
+							{
+								"id": "enigma:specialized_method_name_proposer"
+							},
+							{
+								"id": "enigma:foo",
+								"args": {
+									"base": "org/quiltmc",
+									"packages": ["foo", "bar"],
+									"example": "abc, def, ghi"
+								}
+							}
+						]
+					}
+				}
+				""");
+		EnigmaProfile profile = EnigmaProfile.parse(r);
+
+		Assertions.assertEquals(MappingFileNameFormat.BY_DEOBF, profile.getMappingSaveParameters().fileNameFormat());
+
+		List<EnigmaProfile.Service> decompilers = profile.getServiceProfiles(DecompilerService.TYPE);
+		Assertions.assertEquals(1, decompilers.size());
+		Assertions.assertTrue(decompilers.get(0).matches("enigma:vineflower"));
+
+		List<EnigmaProfile.Service> indexers = profile.getServiceProfiles(JarIndexerService.TYPE);
+		Assertions.assertEquals(1, indexers.size());
+		Optional<String> abc = indexers.get(0).getArgument("abc").flatMap(e -> e.left());
+		Assertions.assertTrue(abc.isPresent());
+		Assertions.assertEquals("hello world", abc.get());
+		Optional<List<String>> foo = indexers.get(0).getArgument("foo").flatMap(e -> e.right());
+		Assertions.assertTrue(foo.isPresent());
+		Assertions.assertEquals(List.of("lorem", "ipsum", "dolor", "sit", "amet"), foo.get());
+
+		List<EnigmaProfile.Service> nameProposers = profile.getServiceProfiles(NameProposalService.TYPE);
+		Assertions.assertEquals(3, nameProposers.size());
+		EnigmaProfile.Service fooService = nameProposers.get(2);
+		Assertions.assertTrue(fooService.getArgument("example").map(Either::isLeft).orElse(false));
+	}
+}


### PR DESCRIPTION
Instead of typing a list as a comma separated string, you can write using json syntax now
```json
{
  "services": {
  "jar_indexer": {
    "id": "enigma:foo",
    "args": {
      "abc": [
        "foo",
        "bar",
        "baz"
      ]
    }
  }
}
```

Would fix the extra long string in the QM profile:
https://github.com/QuiltMC/quilt-mappings/blob/cb88c6627f36721f036e6a1370c14e356cedcdda/enigma_profile.json#L14