### PR TITLE
Keep JAR_PROPOSED mappings separate from other proposals

### DIFF
--- a/enigma-server/src/main/java/org/quiltmc/enigma/network/DedicatedEnigmaServer.java
+++ b/enigma-server/src/main/java/org/quiltmc/enigma/network/DedicatedEnigmaServer.java
@@ -118,10 +118,10 @@ public class DedicatedEnigmaServer extends EnigmaServer {
 			MappingFormat mappingFormat = MappingFormat.parseFromFile(mappingsFile);
 			EntryRemapper mappings;
 			if (!Files.exists(mappingsFile)) {
-				mappings = EntryRemapper.mapped(project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getProposedMappings(), new HashEntryTree<>(), enigma.getNameProposalServices());
+				mappings = EntryRemapper.mapped(project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), new HashEntryTree<>(), enigma.getNameProposalServices());
 			} else {
 				Logger.info("Reading mappings...");
-				mappings = EntryRemapper.mapped(project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getProposedMappings(), mappingFormat.read(mappingsFile), enigma.getNameProposalServices());
+				mappings = EntryRemapper.mapped(project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), mappingFormat.read(mappingsFile), enigma.getNameProposalServices());
 			}
 
 			PrintWriter log = new PrintWriter(Files.newBufferedWriter(logFile));

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/GuiController.java
@@ -614,7 +614,7 @@ public class GuiController implements ClientPacketHandler {
 	}
 
 	public void createServer(int port, char[] password) throws IOException {
-		this.server = new IntegratedEnigmaServer(this.project.getJarChecksum(), password, EntryRemapper.mapped(this.project.getJarIndex(), this.project.getMappingsIndex(), new HashEntryTree<>(this.project.getRemapper().getProposedMappings()), new HashEntryTree<>(this.project.getRemapper().getDeobfMappings()), this.project.getEnigma().getNameProposalServices()), port);
+		this.server = new IntegratedEnigmaServer(this.project.getJarChecksum(), password, EntryRemapper.mapped(this.project.getJarIndex(), this.project.getMappingsIndex(), new HashEntryTree<>(this.project.getRemapper().getJarProposedMappings()), new HashEntryTree<>(this.project.getRemapper().getDeobfMappings()), this.project.getEnigma().getNameProposalServices()), port);
 		this.server.start();
 		this.client = new EnigmaClient(this, "127.0.0.1", port);
 		this.client.connect();

--- a/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProject.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProject.java
@@ -9,7 +9,6 @@ import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.analysis.index.mapping.MappingsIndex;
 import org.quiltmc.enigma.api.service.ObfuscationTestService;
 import org.quiltmc.enigma.api.source.TokenType;
-import org.quiltmc.enigma.api.translation.mapping.tree.EntryTreeNode;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTreeUtil;
 import org.quiltmc.enigma.api.translation.mapping.tree.HashEntryTree;
 import org.quiltmc.enigma.impl.bytecode.translator.TranslationClassVisitor;
@@ -45,7 +44,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -101,21 +99,8 @@ public class EnigmaProject {
 	 * @param progress a progress listener for indexing
 	 */
 	public void setMappings(@Nullable EntryTree<EntryMapping> mappings, ProgressListener progress) {
-		EntryTree<EntryMapping> jarProposedMappings = new HashEntryTree<>();
-
 		// keep bytecode-based proposed names, to avoid unnecessary recalculation
-		if (this.remapper != null) {
-			EntryTree<EntryMapping> oldMappings = this.remapper.getProposedMappings();
-			Iterator<EntryTreeNode<EntryMapping>> iterator = oldMappings.iterator();
-
-			iterator.forEachRemaining(node -> {
-				EntryMapping mapping = node.getValue();
-
-				if (mapping != null && mapping.tokenType() == TokenType.JAR_PROPOSED) {
-					jarProposedMappings.insert(node.getEntry(), mapping);
-				}
-			});
-		}
+		EntryTree<EntryMapping> jarProposedMappings = this.remapper != null ? this.remapper.getJarProposedMappings() : new HashEntryTree<>();
 
 		this.mappingsIndex = MappingsIndex.empty();
 

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 
 public class EntryRemapper {
 	private final EntryTree<EntryMapping> deobfMappings;
+	private final EntryTree<EntryMapping> jarProposedMappings;
 	private final EntryTree<EntryMapping> proposedMappings;
 	private final DeltaTrackingTree<EntryMapping> mappings;
 
@@ -39,10 +40,11 @@ public class EntryRemapper {
 	private final MappingValidator validator;
 	private final List<NameProposalService> proposalServices;
 
-	private EntryRemapper(JarIndex jarIndex, MappingsIndex mappingsIndex, EntryTree<EntryMapping> proposedMappings, EntryTree<EntryMapping> deobfMappings, List<NameProposalService> proposalServices) {
+	private EntryRemapper(JarIndex jarIndex, MappingsIndex mappingsIndex, EntryTree<EntryMapping> jarProposedMappings, EntryTree<EntryMapping> deobfMappings, List<NameProposalService> proposalServices) {
 		this.deobfMappings = deobfMappings;
-		this.proposedMappings = proposedMappings;
-		this.mappings = new DeltaTrackingTree<>(new MergedEntryMappingTree(deobfMappings, proposedMappings));
+		this.jarProposedMappings = jarProposedMappings;
+		this.proposedMappings = new HashEntryTree<>(jarProposedMappings);
+		this.mappings = new DeltaTrackingTree<>(new MergedEntryMappingTree(deobfMappings, this.proposedMappings));
 
 		this.obfResolver = jarIndex.getEntryResolver();
 
@@ -198,6 +200,14 @@ public class EntryRemapper {
 	 */
 	public EntryTree<EntryMapping> getProposedMappings() {
 		return this.proposedMappings;
+	}
+
+	/**
+	 * Gets proposed mappings at the jar indexing stage.
+	 * @return the proposed mapping tree
+	 */
+	public EntryTree<EntryMapping> getJarProposedMappings() {
+		return this.jarProposedMappings;
 	}
 
 	public MappingDelta<EntryMapping> takeMappingDelta() {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
@@ -203,7 +203,7 @@ public class EntryRemapper {
 	}
 
 	/**
-	 * Gets proposed mappings at the jar indexing stage.
+	 * Gets mappings proposed at the jar indexing stage.
 	 * @return the proposed mapping tree
 	 */
 	public EntryTree<EntryMapping> getJarProposedMappings() {


### PR DESCRIPTION
Now all JAR_PROPOSED mappings are restored when reloading mappings. If they were overridden by a dynamic proposal before, they wouldn't be recovered