### PR TITLE
Tokenize the ASM bytecode view

### DIFF
--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/EntryReference.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/EntryReference.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class EntryReference<E extends Entry<?>, C extends Entry<?>> implements Translatable {
-	private static final List<String> CONSTRUCTOR_NON_NAMES = Arrays.asList("this", "super", "static");
+	private static final List<String> CONSTRUCTOR_NON_NAMES = Arrays.asList("this", "super", "static", "<init>", "<clinit>");
 	public final E entry;
 	public final C context;
 	public final ReferenceTargetType targetType;

--- a/enigma/src/main/java/org/quiltmc/enigma/api/source/DecompiledClassSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/source/DecompiledClassSource.java
@@ -53,7 +53,7 @@ public class DecompiledClassSource {
 	private String remapToken(TokenStore target, EnigmaProject project, Token token, Token movedToken, Translator translator) {
 		EntryReference<Entry<?>, Entry<?>> reference = this.obfuscatedIndex.getReference(token);
 
-		Entry<?> entry = reference.getNameableEntry();
+		Entry<?> entry = this.obfuscatedIndex.remapToNameable ? reference.getNameableEntry() : reference.entry;
 		TranslateResult<Entry<?>> translatedEntry = translator.extendedTranslate(entry);
 
 		if (project.isRenamable(reference)) {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/source/SourceIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/source/SourceIndex.java
@@ -21,10 +21,17 @@ public class SourceIndex {
 	private final Multimap<EntryReference<Entry<?>, Entry<?>>, Token> referenceToTokens;
 	private final Map<Entry<?>, Token> declarationToToken;
 
-	public SourceIndex() {
+	public final boolean remapToNameable;
+
+	protected SourceIndex(boolean remapToNameable) {
 		this.tokenToReference = new TreeMap<>();
 		this.referenceToTokens = HashMultimap.create();
 		this.declarationToToken = new LinkedHashMap<>();
+		this.remapToNameable = remapToNameable;
+	}
+
+	public SourceIndex() {
+		this(true);
 	}
 
 	public SourceIndex(String source) {

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeClassEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeClassEntry.java
@@ -1,0 +1,30 @@
+package org.quiltmc.enigma.impl.source.bytecode;
+
+import org.quiltmc.enigma.api.translation.TranslateResult;
+import org.quiltmc.enigma.api.translation.Translator;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+class BytecodeClassEntry extends ClassEntry {
+	BytecodeClassEntry(String className) {
+		super(className);
+	}
+
+	BytecodeClassEntry(@Nullable ClassEntry parent, String className) {
+		super(parent, className);
+	}
+
+	@Override
+	public String getSourceRemapName() {
+		return this.getFullName();
+	}
+
+	@Override
+	public TranslateResult<? extends ClassEntry> extendedTranslate(Translator translator, @Nonnull EntryMapping mapping) {
+		var result = super.extendedTranslate(translator, mapping);
+		return result.map(e -> new BytecodeClassEntry(e.getParent(), e.getName()));
+	}
+}

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
@@ -33,7 +33,7 @@ public class BytecodeSource implements Source {
 
 	@Override
 	public SourceIndex index() {
-		SourceIndex index = new SourceIndex();
+		SourceIndex index = new BytecodeSourceIndex();
 
 		EnigmaTextifier textifier = new EnigmaTextifier(index);
 		StringWriter out = new StringWriter();

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
@@ -1,7 +1,5 @@
 package org.quiltmc.enigma.impl.source.bytecode;
 
-import org.quiltmc.enigma.api.Enigma;
-import org.quiltmc.enigma.impl.bytecode.translator.TranslationClassVisitor;
 import org.quiltmc.enigma.api.source.Source;
 import org.quiltmc.enigma.api.source.SourceIndex;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
@@ -43,23 +41,9 @@ public class BytecodeSource implements Source {
 
 		TraceClassVisitor traceClassVisitor = new TraceClassVisitor(null, textifier, writer);
 
-		ClassNode node = this.classNode;
-
-		// if (this.remapper != null) {
-		// 	ClassNode translatedNode = new ClassNode();
-		// 	node.accept(new TranslationClassVisitor(this.remapper.getDeobfuscator(), Enigma.ASM_VERSION, translatedNode));
-		// 	node = translatedNode;
-		// }
-
-		node.accept(traceClassVisitor);
+		this.classNode.accept(traceClassVisitor);
 
 		for (ClassNode otherNode : this.innerClassNodes) {
-			// if (this.remapper != null) {
-			// 	ClassNode translatedNode = new ClassNode();
-			// 	otherNode.accept(new TranslationClassVisitor(this.remapper.getDeobfuscator(), Enigma.ASM_VERSION, translatedNode));
-			// 	otherNode = translatedNode;
-			// }
-
 			textifier.clearText();
 			writer.println();
 			textifier.skipCharacters(1);

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
@@ -62,6 +62,7 @@ public class BytecodeSource implements Source {
 
 			textifier.clearText();
 			writer.println();
+			textifier.skipCharacters(1);
 			otherNode.accept(traceClassVisitor);
 		}
 

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
@@ -45,11 +45,11 @@ public class BytecodeSource implements Source {
 
 		ClassNode node = this.classNode;
 
-		if (this.remapper != null) {
-			ClassNode translatedNode = new ClassNode();
-			node.accept(new TranslationClassVisitor(this.remapper.getDeobfuscator(), Enigma.ASM_VERSION, translatedNode));
-			node = translatedNode;
-		}
+		// if (this.remapper != null) {
+		// 	ClassNode translatedNode = new ClassNode();
+		// 	node.accept(new TranslationClassVisitor(this.remapper.getDeobfuscator(), Enigma.ASM_VERSION, translatedNode));
+		// 	node = translatedNode;
+		// }
 
 		node.accept(traceClassVisitor);
 

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSource.java
@@ -54,11 +54,11 @@ public class BytecodeSource implements Source {
 		node.accept(traceClassVisitor);
 
 		for (ClassNode otherNode : this.innerClassNodes) {
-			if (this.remapper != null) {
-				ClassNode translatedNode = new ClassNode();
-				otherNode.accept(new TranslationClassVisitor(this.remapper.getDeobfuscator(), Enigma.ASM_VERSION, translatedNode));
-				otherNode = translatedNode;
-			}
+			// if (this.remapper != null) {
+			// 	ClassNode translatedNode = new ClassNode();
+			// 	otherNode.accept(new TranslationClassVisitor(this.remapper.getDeobfuscator(), Enigma.ASM_VERSION, translatedNode));
+			// 	otherNode = translatedNode;
+			// }
 
 			textifier.clearText();
 			writer.println();

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSourceIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/BytecodeSourceIndex.java
@@ -1,0 +1,9 @@
+package org.quiltmc.enigma.impl.source.bytecode;
+
+import org.quiltmc.enigma.api.source.SourceIndex;
+
+class BytecodeSourceIndex extends SourceIndex {
+	BytecodeSourceIndex() {
+		super(false);
+	}
+}

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
@@ -186,7 +186,7 @@ public class EnigmaTextifier extends Textifier {
 		this.queueToken(new QueuedToken.Array(
 			new QueuedToken.Descriptor(descriptor), // field descriptor
 			new QueuedToken.OffsetToken(descriptor.length() + 1, name,
-				new QueuedToken.Reference(new FieldEntry(this.currentClass, name, new TypeDescriptor(descriptor)), this.currentMethod)) // field (on its name)
+				new QueuedToken.Declaration(new FieldEntry(this.currentClass, name, new TypeDescriptor(descriptor)))) // field (on its name)
 		));
 
 		return super.visitField(access, name, descriptor, signature, value);
@@ -201,7 +201,7 @@ public class EnigmaTextifier extends Textifier {
 		var entry = new MethodEntry(this.currentClass, name, new MethodDescriptor(descriptor));
 		this.queueToken(new QueuedToken.Array(
 			new QueuedToken.OffsetToken(-name.length(), name,
-				new QueuedToken.Reference(entry, this.currentMethod)), // method (on its name)
+				new QueuedToken.Declaration(entry)), // method (on its name)
 			new QueuedToken.MethodDescriptor(descriptor) // method descriptor
 		));
 

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
@@ -69,6 +69,8 @@ public class EnigmaTextifier extends Textifier {
 		}
 	}
 
+	private static final String MODULE_WARNING = "  // Warning: Modules are not supported\n";
+
 	private final SourceIndex sourceIndex;
 
 	private final Deque<QueuedToken> tokenQueue = new ArrayDeque<>();
@@ -118,7 +120,7 @@ public class EnigmaTextifier extends Textifier {
 
 	@Override
 	public Printer visitModule(String name, int access, String version) {
-		return super.visitModule(name, access, version); // TODO
+		return super.visitModule(name, access, version);
 	}
 
 	@Override
@@ -242,6 +244,12 @@ public class EnigmaTextifier extends Textifier {
 	// region module printer
 
 	@Override
+	public void visitMainClass(String mainClass) {
+		this.text.add(MODULE_WARNING);
+		super.visitMainClass(mainClass);
+	}
+
+	@Override
 	public void visitModuleEnd() {
 		super.visitModuleEnd();
 		this.fillTokensPerText();
@@ -250,6 +258,13 @@ public class EnigmaTextifier extends Textifier {
 	// endregion
 
 	// region annotation printer
+
+	@Override
+	public Textifier visitAnnotation(String name, String descriptor) {
+		this.queueToken(new QueuedToken.Descriptor(descriptor, this.currentMethod));
+
+		return super.visitAnnotation(name, descriptor);
+	}
 
 	@Override
 	public void visitAnnotationEnd() {
@@ -285,6 +300,24 @@ public class EnigmaTextifier extends Textifier {
 	public void visitMethodEnd() {
 		super.visitMethodEnd();
 		this.fillTokensPerText();
+	}
+
+	// endregion
+
+	// region printer extra
+
+	@Override
+	public Textifier visitAnnotation(String descriptor, boolean visible) {
+		this.queueToken(new QueuedToken.Descriptor(descriptor, this.currentMethod));
+
+		return super.visitAnnotation(descriptor, visible);
+	}
+
+	@Override
+	public Textifier visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
+		this.queueToken(new QueuedToken.Descriptor(descriptor, this.currentMethod));
+
+		return super.visitTypeAnnotation(typeRef, typePath, descriptor, visible);
 	}
 
 	// endregion

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
@@ -45,7 +45,7 @@ public class EnigmaTextifier extends Textifier {
 		}
 
 		record Signature() implements QueuedToken {
-		} // TODO
+		}
 
 		record OffsetToken(int offset, String text, QueuedToken token) implements QueuedToken {
 		}

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
@@ -409,7 +409,7 @@ public class EnigmaTextifier extends Textifier {
 		} else if (queuedToken instanceof QueuedToken.Reference r) {
 			tokens.add(new PartialToken(tokenStart, text, r.entry, r.context));
 		} else if (queuedToken instanceof QueuedToken.Descriptor d) {
-			var clazz = d.descriptor.substring(d.descriptor.indexOf('L'), d.descriptor.length() - 1);
+			var clazz = d.descriptor.substring(d.descriptor.indexOf('L') + 1, d.descriptor.length() - 1);
 			tokens.add(new PartialToken(tokenStart + 1, clazz, new ClassEntry(clazz), null));
 		} else if (queuedToken instanceof QueuedToken.MethodDescriptor d) {
 			for (int i = 1; i < d.descriptor.length(); i++) {

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
@@ -1,11 +1,67 @@
 package org.quiltmc.enigma.impl.source.bytecode;
 
+import org.objectweb.asm.Attribute;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.util.Printer;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.source.SourceIndex;
 import org.objectweb.asm.util.Textifier;
+import org.quiltmc.enigma.api.source.Token;
+import org.quiltmc.enigma.api.translation.representation.MethodDescriptor;
+import org.quiltmc.enigma.api.translation.representation.TypeDescriptor;
+import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class EnigmaTextifier extends Textifier {
 	private final SourceIndex sourceIndex;
+
+	sealed interface QueuedToken {
+		record Declaration(Entry<?> entry) implements QueuedToken {
+		}
+
+		record Reference(Entry<?> entry, Entry<?> context) implements QueuedToken {
+		}
+
+		record Descriptor(String descriptor, Entry<?> context) implements QueuedToken {
+			@Override
+			public boolean shouldSkip() {
+				return !this.descriptor.startsWith("L");
+			}
+		}
+
+		record MethodDescriptor(String descriptor, Entry<?> context) implements QueuedToken {
+		}
+
+		record Signature() implements QueuedToken {
+		} // TODO
+
+		record OffsetToken(int offset, String text, QueuedToken token) implements QueuedToken {
+		}
+
+		record Multiple(QueuedToken... tokens) implements QueuedToken {
+		}
+
+		record Skip() implements QueuedToken {
+		}
+
+		default boolean shouldSkip() {
+			return this instanceof Skip || this instanceof Signature; // Skip signatures for now
+		}
+	}
+
+	/**
+	 * A queue to collect tokens on {@link #appendDescriptor(int, String)}.
+	 */
+	private final Deque<QueuedToken> tokenQueue = new ArrayDeque<>();
+
+	private ClassEntry currentClass;
+	private MethodEntry currentMethod;
+	private int currentOffset = 0;
 
 	public EnigmaTextifier(SourceIndex sourceIndex) {
 		super(Enigma.ASM_VERSION);
@@ -14,5 +70,240 @@ public class EnigmaTextifier extends Textifier {
 
 	public void clearText() {
 		this.text.clear();
+	}
+
+	private void updateOffset() {
+		if (this.text.isEmpty()) {
+			return;
+		}
+
+		var lastText = this.text.get(this.text.size() - 1);
+		if (lastText instanceof String s) {
+			this.currentOffset += s.length();
+		}
+	}
+
+	// region class printer
+	@Override
+	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+		this.currentClass = new ClassEntry(name);
+
+		this.queueToken(new QueuedToken.Signature()); // class signature
+		this.queueToken(new QueuedToken.Declaration(this.currentClass)); // class name
+		if (superName != null && !"java/lang/Object".equals(superName)) {
+			this.queueToken(new QueuedToken.Reference(new ClassEntry(superName), this.currentMethod)); // extended class name
+		}
+
+		if (interfaces != null) {
+			for (String interfaceName : interfaces) {
+				this.queueToken(new QueuedToken.Reference(new ClassEntry(interfaceName), this.currentMethod)); // implemented interface name
+			}
+		}
+
+		super.visit(version, access, name, signature, superName, interfaces);
+		this.updateOffset();
+	}
+
+	@Override
+	public void visitSource(String file, String debug) {
+		super.visitSource(file, debug);
+		this.updateOffset();
+	}
+
+	@Override
+	public Printer visitModule(String name, int access, String version) {
+		var r = super.visitModule(name, access, version);
+		this.updateOffset();
+		return r; // TODO
+	}
+
+	@Override
+	public void visitNestHost(String nestHost) {
+		this.queueToken(new QueuedToken.Reference(new ClassEntry(nestHost), this.currentMethod)); // nest host
+
+		super.visitNestHost(nestHost);
+		this.updateOffset();
+	}
+
+	@Override
+	public void visitOuterClass(String owner, String name, String descriptor) {
+		// JVMS§4.7.7
+		var ownerEntry = new ClassEntry(owner);
+		this.queueToken(new QueuedToken.Reference(ownerEntry, this.currentMethod)); // outer class
+
+		if (name != null) {
+			this.queueToken(new QueuedToken.Multiple(
+				new QueuedToken.OffsetToken(-name.length() - 1, name,
+					new QueuedToken.Reference(new MethodEntry(ownerEntry, name, new MethodDescriptor(descriptor)), this.currentMethod)), // enclosing method (by its name)
+				new QueuedToken.MethodDescriptor(descriptor, this.currentMethod) // enclosing method descriptor
+			));
+		}
+
+		super.visitOuterClass(owner, name, descriptor);
+		this.updateOffset();
+	}
+
+	@Override
+	public Textifier visitClassAnnotation(String descriptor, boolean visible) {
+		var r = super.visitClassAnnotation(descriptor, visible);
+		this.updateOffset();
+		return r;
+	}
+
+	@Override
+	public Printer visitClassTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
+		var r = super.visitClassTypeAnnotation(typeRef, typePath, descriptor, visible);
+		this.updateOffset();
+		return r;
+	}
+
+	@Override
+	public void visitClassAttribute(Attribute attribute) {
+		this.currentOffset++; // can't do updateOffset since the last text after visiting is the attribute info, not the newline
+		super.visitClassAttribute(attribute);
+	}
+
+	@Override
+	public void visitNestMember(String nestMember) {
+		this.queueToken(new QueuedToken.Reference(new ClassEntry(nestMember), this.currentMethod));
+		super.visitNestMember(nestMember);
+		this.currentOffset += this.stringBuilder.length();
+	}
+
+	@Override
+	public void visitPermittedSubclass(String permittedSubclass) {
+		this.queueToken(new QueuedToken.Reference(new ClassEntry(permittedSubclass), this.currentMethod));
+		super.visitPermittedSubclass(permittedSubclass);
+		this.currentOffset += this.stringBuilder.length();
+	}
+
+	@Override
+	public void visitInnerClass(String name, String outerName, String innerName, int access) {
+		// JVMS§4.7.6
+		this.queueToken(new QueuedToken.Reference(new ClassEntry(name), this.currentMethod));
+		this.queueToken(outerName != null ? new QueuedToken.Reference(new ClassEntry(outerName), this.currentMethod) : new QueuedToken.Skip());
+		super.visitInnerClass(name, outerName, innerName, access);
+		this.currentOffset += this.stringBuilder.length();
+	}
+
+	@Override
+	public Printer visitRecordComponent(String name, String descriptor, String signature) {
+		if (signature != null) {
+			this.queueToken(new QueuedToken.Signature()); // component signature
+		}
+
+		this.queueToken(new QueuedToken.Multiple(
+			new QueuedToken.MethodDescriptor(descriptor, this.currentMethod), // component descriptor
+			new QueuedToken.OffsetToken(descriptor.length() + 1, name,
+				new QueuedToken.Reference(new FieldEntry(this.currentClass, name, new TypeDescriptor(descriptor)), this.currentMethod)) // component field
+		));
+
+		var r = super.visitRecordComponent(name, descriptor, signature);
+		this.currentOffset += this.stringBuilder.length();
+		return r;
+	}
+
+	@Override
+	public Textifier visitField(int access, String name, String descriptor, String signature, Object value) {
+		if (signature != null) {
+			this.queueToken(new QueuedToken.Signature());
+		}
+
+		this.queueToken(new QueuedToken.Multiple(
+			new QueuedToken.Descriptor(descriptor, this.currentMethod), // field descriptor
+			new QueuedToken.OffsetToken(descriptor.length() + 1, name,
+				new QueuedToken.Reference(new FieldEntry(this.currentClass, name, new TypeDescriptor(descriptor)), this.currentMethod)) // field (on its name)
+		));
+
+		var r = super.visitField(access, name, descriptor, signature, value);
+		this.currentOffset += this.stringBuilder.length();
+		return r; // TODO
+	}
+
+	@Override
+	public Textifier visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+		if (signature != null) {
+			this.queueToken(new QueuedToken.Signature());
+		}
+
+		this.queueToken(new QueuedToken.Multiple(
+			new QueuedToken.OffsetToken(-name.length(), name,
+				new QueuedToken.Reference(new MethodEntry(this.currentClass, name, new MethodDescriptor(descriptor)), this.currentMethod)), // method (on its name)
+			new QueuedToken.Descriptor(descriptor, this.currentMethod) // method descriptor
+		));
+
+		if (exceptions != null) {
+			for (var exception : exceptions) {
+				this.queueToken(new QueuedToken.Reference(new ClassEntry(exception), this.currentMethod)); // thrown exception
+			}
+		}
+
+		var r = super.visitMethod(access, name, descriptor, signature, exceptions);
+		this.currentOffset += this.stringBuilder.length();
+		return r; // TODO
+	}
+
+	@Override
+	public void visitClassEnd() {
+		super.visitClassEnd();
+	}
+
+	// endregion
+
+	@Override
+	public void visitAttribute(Attribute attribute) {
+		super.visitAttribute(attribute);
+		this.updateOffset();
+	}
+
+	private void queueToken(QueuedToken token) {
+		this.tokenQueue.add(token);
+	}
+
+	@Override
+	protected void appendDescriptor(int type, String value) {
+		int tokenOffset = this.stringBuilder.length();
+
+		super.appendDescriptor(type, value);
+
+		var queuedToken = this.tokenQueue.poll();
+		this.addToken(value, tokenOffset, queuedToken);
+	}
+
+	private void addToken(String value, int tokenOffset, QueuedToken queuedToken) {
+		if (queuedToken == null || queuedToken.shouldSkip()) {
+			return;
+		} else if (queuedToken instanceof QueuedToken.Multiple multiple) {
+			for (var token : multiple.tokens) {
+				this.addToken(value, tokenOffset, token);
+			}
+
+			return;
+		} else if (queuedToken instanceof QueuedToken.OffsetToken t) {
+			this.addToken(t.text, tokenOffset + t.offset, t.token);
+			return;
+		}
+
+		int start = this.currentOffset + tokenOffset;
+		var token = new Token(start, start + value.length(), value);
+
+		// This would be far simpler with pattern matching
+		if (queuedToken instanceof QueuedToken.Declaration d) {
+			this.sourceIndex.addDeclaration(token, d.entry);
+		} else if (queuedToken instanceof QueuedToken.Reference r) {
+			this.sourceIndex.addReference(token, r.entry, r.context);
+		} else if (queuedToken instanceof QueuedToken.Descriptor d) {
+			token.start += 1;
+			token.end -= 1;
+			token.text = d.descriptor.substring(1, d.descriptor.length() - 1);
+			this.sourceIndex.addReference(token, new ClassEntry(token.text), d.context);
+		} else if (queuedToken instanceof QueuedToken.Signature s) {
+			// TODO
+		}
+	}
+
+	@Override
+	protected Textifier createTextifier() {
+		return super.createTextifier();
 	}
 }

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/bytecode/EnigmaTextifier.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.impl.source.bytecode;
 
-import org.objectweb.asm.Attribute;
 import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.TypePath;
@@ -37,7 +36,7 @@ public class EnigmaTextifier extends Textifier {
 		record Descriptor(String descriptor) implements QueuedToken {
 			@Override
 			public boolean shouldSkip() {
-				return !this.descriptor.startsWith("L");
+				return !this.descriptor.contains("L");
 			}
 		}
 
@@ -410,7 +409,7 @@ public class EnigmaTextifier extends Textifier {
 		} else if (queuedToken instanceof QueuedToken.Reference r) {
 			tokens.add(new PartialToken(tokenStart, text, r.entry, r.context));
 		} else if (queuedToken instanceof QueuedToken.Descriptor d) {
-			var clazz = d.descriptor.substring(1, d.descriptor.length() - 1);
+			var clazz = d.descriptor.substring(d.descriptor.indexOf('L'), d.descriptor.length() - 1);
 			tokens.add(new PartialToken(tokenStart + 1, clazz, new ClassEntry(clazz), null));
 		} else if (queuedToken instanceof QueuedToken.MethodDescriptor d) {
 			for (int i = 1; i < d.descriptor.length(); i++) {

--- a/enigma/src/main/java/org/quiltmc/enigma/util/Pair.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/util/Pair.java
@@ -4,6 +4,11 @@ import java.util.Objects;
 
 public record Pair<A, B>(A a, B b) {
 	@Override
+	public int hashCode() {
+		return this.a.hashCode() ^ this.b.hashCode();
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		return o instanceof Pair
 				&& Objects.equals(this.a, ((Pair<?, ?>) o).a)


### PR DESCRIPTION
Fixes #40. Only thing left is to display the constructors of mapped classes as `<init>`s

![image](https://github.com/QuiltMC/enigma/assets/47987888/d8b847ed-17eb-4e86-8a03-529361bb54b7)
