### PR TITLE
fixes to mappings index

### DIFF
--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/mapping/PackageIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/mapping/PackageIndex.java
@@ -6,7 +6,6 @@ import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,14 +29,9 @@ public class PackageIndex implements MappingsIndexer {
 		if (name != null) {
 			// index all different versions of the package name
 			// note we're not avoiding duplicates: otherwise reindexing would erroneously remove package names
-			List<String> names = new ArrayList<>();
 			while (name != null && name.contains("/")) {
 				name = ClassEntry.getParentPackage(name);
-				names.add(name);
-			}
-
-			for (String p : names) {
-				this.packageNames.put(entry, p);
+				this.packageNames.put(entry, name);
 			}
 		}
 	}

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -266,7 +266,7 @@
 	"validation.message.field_length_out_of_range": "Value must be less than %d characters long.",
 	"validation.message.non_unique_name_class": "Name '%s' is not unique in '%s'.",
 	"validation.message.non_unique_name": "Name '%s' is not unique.",
-	"validation.message.new_package": "This rename will create a new package: '%s'",
+	"validation.message.new_package": "This rename will be the first mapped class in the package '%s'",
 	"validation.message.illegal_class_name": "'%s' is not a valid class name.",
 	"validation.message.illegal_identifier": "'%s' is not a valid identifier.",
 	"validation.message.illegal_identifier.long": "Invalid character '%2$s' at position %3$d.",


### PR DESCRIPTION
- mappings index was skipping entries due to me using my own stupid way of collecting nodes
- package index only indexed the last package in the heirarchy for each class
- package index depended on one sole class for each package, meaning if you renamed that one it "forgot" that package existed
- the message was sometimes a little bit misleading, since unmapped classes don't get their packages indexed