### PR TITLE
Resolve the correct amount of entries when renaming a method

### DIFF
--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
@@ -20,11 +20,8 @@ import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.util.validation.Message;
 import org.quiltmc.enigma.util.validation.ValidationContext;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.List;

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
@@ -87,7 +87,7 @@ public class EntryRemapper {
 		EntryMapping oldMapping = this.getMapping(obfuscatedEntry);
 		boolean renaming = !Objects.equals(oldMapping.targetName(), deobfMapping.targetName());
 
-		Collection<Entry<?>> resolvedEntries = renaming ? resolveAllRoots(obfuscatedEntry) : this.obfResolver.resolveEntry(obfuscatedEntry, ResolutionStrategy.RESOLVE_CLOSEST);
+		Collection<Entry<?>> resolvedEntries = renaming ? this.resolveAllRoots(obfuscatedEntry) : this.obfResolver.resolveEntry(obfuscatedEntry, ResolutionStrategy.RESOLVE_CLOSEST);
 
 		if (renaming && deobfMapping.targetName() != null) {
 			for (Entry<?> resolvedEntry : resolvedEntries) {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
@@ -119,6 +119,9 @@ public class EntryRemapper {
 		var descendants = inheritanceIndex.getDescendants(owner);
 		var knownParents = new HashSet<>(inheritanceIndex.getParents(owner));
 
+		// Find all classes with an "unknown" parent, so we can also resolve the method from there and find other definitions
+		// If interfaces A and B define method `void foo()`, a class C may implement both interfaces, having a single method `void foo()`
+		// and effectively "joining" the two interface methods, so you have to keep both "in sync"
 		List<ClassEntry> classes = new ArrayList<>();
 		for (ClassEntry descendant : descendants) {
 			var parents = inheritanceIndex.getParents(descendant);

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/AInterface.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/AInterface.java
@@ -1,0 +1,9 @@
+package org.quiltmc.enigma.input.interface_union;
+
+public interface AInterface {
+	int methodA();
+
+	void methodFoo();
+
+	double baz();
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/AInterface.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/AInterface.java
@@ -3,7 +3,9 @@ package org.quiltmc.enigma.input.interface_union;
 public interface AInterface {
 	int methodA();
 
+	// BInterface -> Union1Class
 	void methodFoo();
 
+	// -> Union3Record
 	double baz();
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/BInterface.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/BInterface.java
@@ -1,9 +1,11 @@
 package org.quiltmc.enigma.input.interface_union;
 
 public interface BInterface {
+	// AInterface -> Union1Class
 	void methodFoo();
 
 	double methodB();
 
+	// CClass -> Union2Class
 	boolean methodBar();
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/BInterface.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/BInterface.java
@@ -1,0 +1,9 @@
+package org.quiltmc.enigma.input.interface_union;
+
+public interface BInterface {
+	void methodFoo();
+
+	double methodB();
+
+	boolean methodBar();
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/CClass.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/CClass.java
@@ -1,6 +1,7 @@
 package org.quiltmc.enigma.input.interface_union;
 
 public class CClass {
+	// BInterface -> Union2Class
 	public boolean methodBar() {
 		return true;
 	}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/CClass.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/CClass.java
@@ -1,0 +1,7 @@
+package org.quiltmc.enigma.input.interface_union;
+
+public class CClass {
+	public boolean methodBar() {
+		return true;
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/CClass.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/CClass.java
@@ -1,8 +1,15 @@
 package org.quiltmc.enigma.input.interface_union;
 
+import java.util.Random;
+
 public class CClass {
 	// BInterface -> Union2Class
 	public boolean methodBar() {
 		return true;
+	}
+
+	// DInterface -> Union4Class
+	public float factor() {
+		return (float) new Random().nextGaussian();
 	}
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/DInterface.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/DInterface.java
@@ -1,0 +1,5 @@
+package org.quiltmc.enigma.input.interface_union;
+
+public interface DInterface {
+	float factor();
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union1Class.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union1Class.java
@@ -8,6 +8,7 @@ public class Union1Class implements AInterface, BInterface {
 		return 32767;
 	}
 
+	// AInterface + BInterface
 	@Override
 	public void methodFoo() {
 		System.out.println("foo");

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union1Class.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union1Class.java
@@ -1,0 +1,30 @@
+package org.quiltmc.enigma.input.interface_union;
+
+import java.util.Random;
+
+public class Union1Class implements AInterface, BInterface {
+	@Override
+	public int methodA() {
+		return 32767;
+	}
+
+	@Override
+	public void methodFoo() {
+		System.out.println("foo");
+	}
+
+	@Override
+	public double baz() {
+		return 200;
+	}
+
+	@Override
+	public double methodB() {
+		return new Random().nextGaussian();
+	}
+
+	@Override
+	public boolean methodBar() {
+		return false;
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union2Class.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union2Class.java
@@ -1,0 +1,19 @@
+package org.quiltmc.enigma.input.interface_union;
+
+import java.util.Random;
+
+public class Union2Class extends CClass implements BInterface {
+	@Override
+	public void methodFoo() {
+	}
+
+	@Override
+	public double methodB() {
+		return 6.02e23;
+	}
+
+	@Override
+	public boolean methodBar() {
+		return new Random().nextExponential() > 2.0;
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union2Class.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union2Class.java
@@ -12,6 +12,7 @@ public class Union2Class extends CClass implements BInterface {
 		return 6.02e23;
 	}
 
+	// BInterface + CClass
 	@Override
 	public boolean methodBar() {
 		return new Random().nextExponential() > 2.0;

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union3Record.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union3Record.java
@@ -9,4 +9,6 @@ public record Union3Record(double baz) implements AInterface {
 	@Override
 	public void methodFoo() {
 	}
+
+	// AInterface -> baz()
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union3Record.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union3Record.java
@@ -1,0 +1,12 @@
+package org.quiltmc.enigma.input.interface_union;
+
+public record Union3Record(double baz) implements AInterface {
+	@Override
+	public int methodA() {
+		return -1;
+	}
+
+	@Override
+	public void methodFoo() {
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union4Class.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interface_union/Union4Class.java
@@ -1,0 +1,5 @@
+package org.quiltmc.enigma.input.interface_union;
+
+public class Union4Class extends CClass implements DInterface {
+	// DInterface.factor() implemented in CClass
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/EntryRemapperTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/EntryRemapperTest.java
@@ -1,0 +1,110 @@
+package org.quiltmc.enigma.translation.mapping;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.enigma.TestEntryFactory;
+import org.quiltmc.enigma.TestUtil;
+import org.quiltmc.enigma.api.Enigma;
+import org.quiltmc.enigma.api.EnigmaProject;
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
+import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
+import org.quiltmc.enigma.api.translation.mapping.tree.HashEntryTree;
+import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.util.validation.ParameterizedMessage;
+import org.quiltmc.enigma.util.validation.ValidationContext;
+
+import java.nio.file.Path;
+
+public class EntryRemapperTest {
+	public static final Path JAR = TestUtil.obfJar("interface_union");
+	private static EnigmaProject project;
+	private static EntryRemapper remapper;
+
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		Enigma enigma = Enigma.create();
+		project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.none());
+		remapper = project.getRemapper();
+	}
+
+	@BeforeEach
+	public void beforeEach() {
+		EntryTree<EntryMapping> mappings = new HashEntryTree<>();
+		project.setMappings(mappings, ProgressListener.none());
+		remapper = project.getRemapper();
+	}
+
+	private static void assertName(Entry<?> entry, String expected) {
+		Entry<?> deobf = remapper.deobfuscate(entry);
+		Assertions.assertNotNull(deobf);
+		Assertions.assertEquals(expected, deobf.getName());
+	}
+
+	@Test
+	public void testUnionRename() {
+		var name = "unionAB";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("d", "a", "()V"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("d", "a", "()V"), name);
+		assertName(TestEntryFactory.newMethod("a", "a", "()V"), name);
+		assertName(TestEntryFactory.newMethod("b", "a", "()V"), name);
+
+		name = "unionBC";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("e", "a", "()Z"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("e", "a", "()Z"), name);
+		assertName(TestEntryFactory.newMethod("b", "a", "()Z"), name);
+		assertName(TestEntryFactory.newMethod("c", "a", "()Z"), name);
+
+		name = "unionA3";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("f", "a", "()D"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("f", "a", "()D"), name);
+		assertName(TestEntryFactory.newMethod("a", "a", "()D"), name);
+	}
+
+	@Test
+	public void testElementRename() {
+		var name = "unionAB";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("a", "a", "()V"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("a", "a", "()V"), name);
+		assertName(TestEntryFactory.newMethod("d", "a", "()V"), name);
+		assertName(TestEntryFactory.newMethod("b", "a", "()V"), name);
+
+		name = "unionBC";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "a", "()Z"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("b", "a", "()Z"), name);
+		assertName(TestEntryFactory.newMethod("e", "a", "()Z"), name);
+		assertName(TestEntryFactory.newMethod("c", "a", "()Z"), name);
+
+		name = "unionA3";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("a", "a", "()D"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("a", "a", "()D"), name);
+		assertName(TestEntryFactory.newMethod("f", "a", "()D"), name);
+	}
+
+	private static ValidationContext newVC() {
+		return new ValidationContext(notifier());
+	}
+
+	private static ValidationContext.Notifier notifier() {
+		return new ValidationContext.Notifier() {
+			@Override
+			public void notify(ParameterizedMessage message) {
+			}
+
+			@Override
+			public boolean verifyWarning(ParameterizedMessage message) {
+				return true;
+			}
+		};
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/EntryRemapperTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/EntryRemapperTest.java
@@ -48,47 +48,59 @@ public class EntryRemapperTest {
 	@Test
 	public void testUnionRename() {
 		var name = "unionAB";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("d", "a", "()V"), new EntryMapping(name));
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("e", "a", "()V"), new EntryMapping(name));
 
-		assertName(TestEntryFactory.newMethod("d", "a", "()V"), name);
+		assertName(TestEntryFactory.newMethod("e", "a", "()V"), name);
 		assertName(TestEntryFactory.newMethod("a", "a", "()V"), name);
 		assertName(TestEntryFactory.newMethod("b", "a", "()V"), name);
 
 		name = "unionBC";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("e", "a", "()Z"), new EntryMapping(name));
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("f", "a", "()Z"), new EntryMapping(name));
 
-		assertName(TestEntryFactory.newMethod("e", "a", "()Z"), name);
+		assertName(TestEntryFactory.newMethod("f", "a", "()Z"), name);
 		assertName(TestEntryFactory.newMethod("b", "a", "()Z"), name);
 		assertName(TestEntryFactory.newMethod("c", "a", "()Z"), name);
 
 		name = "unionA3";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("f", "a", "()D"), new EntryMapping(name));
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("g", "a", "()D"), new EntryMapping(name));
 
-		assertName(TestEntryFactory.newMethod("f", "a", "()D"), name);
+		assertName(TestEntryFactory.newMethod("g", "a", "()D"), name);
 		assertName(TestEntryFactory.newMethod("a", "a", "()D"), name);
 	}
 
 	@Test
 	public void testElementRename() {
 		var name = "unionAB";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("a", "a", "()V"), new EntryMapping(name));
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("e", "a", "()V"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("a", "a", "()V"), name);
-		assertName(TestEntryFactory.newMethod("d", "a", "()V"), name);
+		assertName(TestEntryFactory.newMethod("e", "a", "()V"), name);
 		assertName(TestEntryFactory.newMethod("b", "a", "()V"), name);
 
 		name = "unionBC";
 		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "a", "()Z"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("b", "a", "()Z"), name);
-		assertName(TestEntryFactory.newMethod("e", "a", "()Z"), name);
+		assertName(TestEntryFactory.newMethod("f", "a", "()Z"), name);
 		assertName(TestEntryFactory.newMethod("c", "a", "()Z"), name);
 
 		name = "unionA3";
 		remapper.putMapping(newVC(), TestEntryFactory.newMethod("a", "a", "()D"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("a", "a", "()D"), name);
-		assertName(TestEntryFactory.newMethod("f", "a", "()D"), name);
+		assertName(TestEntryFactory.newMethod("g", "a", "()D"), name);
+
+		name = "unionCD";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("c", "a", "()F"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("c", "a", "()F"), name);
+		assertName(TestEntryFactory.newMethod("d", "a", "()F"), name);
+
+		name = "unionDC";
+		remapper.putMapping(newVC(), TestEntryFactory.newMethod("d", "a", "()F"), new EntryMapping(name));
+
+		assertName(TestEntryFactory.newMethod("d", "a", "()F"), name);
+		assertName(TestEntryFactory.newMethod("c", "a", "()F"), name);
 	}
 
 	private static ValidationContext newVC() {

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/EntryRemapperTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/EntryRemapperTest.java
@@ -15,8 +15,6 @@ import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
 import org.quiltmc.enigma.api.translation.mapping.tree.HashEntryTree;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
-import org.quiltmc.enigma.util.validation.ParameterizedMessage;
-import org.quiltmc.enigma.util.validation.ValidationContext;
 
 import java.nio.file.Path;
 
@@ -48,21 +46,21 @@ public class EntryRemapperTest {
 	@Test
 	public void testUnionRename() {
 		var name = "unionAB";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("e", "a", "()V"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("e", "a", "()V"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("e", "a", "()V"), name);
 		assertName(TestEntryFactory.newMethod("a", "a", "()V"), name);
 		assertName(TestEntryFactory.newMethod("b", "a", "()V"), name);
 
 		name = "unionBC";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("f", "a", "()Z"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("f", "a", "()Z"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("f", "a", "()Z"), name);
 		assertName(TestEntryFactory.newMethod("b", "a", "()Z"), name);
 		assertName(TestEntryFactory.newMethod("c", "a", "()Z"), name);
 
 		name = "unionA3";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("g", "a", "()D"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("g", "a", "()D"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("g", "a", "()D"), name);
 		assertName(TestEntryFactory.newMethod("a", "a", "()D"), name);
@@ -71,52 +69,35 @@ public class EntryRemapperTest {
 	@Test
 	public void testElementRename() {
 		var name = "unionAB";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("e", "a", "()V"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("e", "a", "()V"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("a", "a", "()V"), name);
 		assertName(TestEntryFactory.newMethod("e", "a", "()V"), name);
 		assertName(TestEntryFactory.newMethod("b", "a", "()V"), name);
 
 		name = "unionBC";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "a", "()Z"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("b", "a", "()Z"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("b", "a", "()Z"), name);
 		assertName(TestEntryFactory.newMethod("f", "a", "()Z"), name);
 		assertName(TestEntryFactory.newMethod("c", "a", "()Z"), name);
 
 		name = "unionA3";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("a", "a", "()D"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("a", "a", "()D"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("a", "a", "()D"), name);
 		assertName(TestEntryFactory.newMethod("g", "a", "()D"), name);
 
 		name = "unionCD";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("c", "a", "()F"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("c", "a", "()F"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("c", "a", "()F"), name);
 		assertName(TestEntryFactory.newMethod("d", "a", "()F"), name);
 
 		name = "unionDC";
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("d", "a", "()F"), new EntryMapping(name));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("d", "a", "()F"), new EntryMapping(name));
 
 		assertName(TestEntryFactory.newMethod("d", "a", "()F"), name);
 		assertName(TestEntryFactory.newMethod("c", "a", "()F"), name);
-	}
-
-	private static ValidationContext newVC() {
-		return new ValidationContext(notifier());
-	}
-
-	private static ValidationContext.Notifier notifier() {
-		return new ValidationContext.Notifier() {
-			@Override
-			public void notify(ParameterizedMessage message) {
-			}
-
-			@Override
-			public boolean verifyWarning(ParameterizedMessage message) {
-				return true;
-			}
-		};
 	}
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidator.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidator.java
@@ -45,33 +45,33 @@ public class TestMappingValidator {
 
 		// repeat with mapped classes
 		if (repetitionInfo.getCurrentRepetition() == 1) {
-			remapper.putMapping(newVC(), TestEntryFactory.newClass("a"), new EntryMapping("BaseClass"));
-			remapper.putMapping(newVC(), TestEntryFactory.newClass("b"), new EntryMapping("SuperClass"));
+			remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newClass("a"), new EntryMapping("BaseClass"));
+			remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newClass("b"), new EntryMapping("SuperClass"));
 		}
 	}
 
 	@RepeatedTest(value = 2, name = REPEATED_TEST_NAME)
 	public void shadowPrivateFields() {
 		// static fields
-		remapper.putMapping(newVC(), TestEntryFactory.newField("b", "a", "Ljava/lang/String;"), new EntryMapping("FIELD_00"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newField("b", "a", "Ljava/lang/String;"), new EntryMapping("FIELD_00"));
 
-		ValidationContext vc = new ValidationContext(notifier());
+		ValidationContext vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newField("a", "c", "Ljava/lang/String;"), new EntryMapping("FIELD_00"));
 
 		assertMessages(vc, Message.SHADOWED_NAME_CLASS);
 
 		// final fields
-		remapper.putMapping(newVC(), TestEntryFactory.newField("b", "a", "I"), new EntryMapping("field01"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newField("b", "a", "I"), new EntryMapping("field01"));
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newField("a", "a", "I"), new EntryMapping("field01"));
 
 		assertMessages(vc);
 
 		// instance fields
-		remapper.putMapping(newVC(), TestEntryFactory.newField("b", "b", "I"), new EntryMapping("field02"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newField("b", "b", "I"), new EntryMapping("field02"));
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newField("a", "b", "I"), new EntryMapping("field02"));
 
 		assertMessages(vc);
@@ -80,17 +80,17 @@ public class TestMappingValidator {
 	@RepeatedTest(value = 2, name = REPEATED_TEST_NAME)
 	public void shadowPublicFields() {
 		// static fields
-		remapper.putMapping(newVC(), TestEntryFactory.newField("b", "b", "Ljava/lang/String;"), new EntryMapping("FIELD_04"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newField("b", "b", "Ljava/lang/String;"), new EntryMapping("FIELD_04"));
 
-		ValidationContext vc = new ValidationContext(notifier());
+		ValidationContext vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newField("a", "a", "Ljava/lang/String;"), new EntryMapping("FIELD_04"));
 
 		assertMessages(vc, Message.SHADOWED_NAME_CLASS);
 
 		// default fields
-		remapper.putMapping(newVC(), TestEntryFactory.newField("b", "b", "Z"), new EntryMapping("field05"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newField("b", "b", "Z"), new EntryMapping("field05"));
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newField("a", "a", "Z"), new EntryMapping("field05"));
 
 		assertMessages(vc);
@@ -99,17 +99,17 @@ public class TestMappingValidator {
 	@RepeatedTest(value = 2, name = REPEATED_TEST_NAME)
 	public void shadowMethods() {
 		// static methods
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "c", "()V"), new EntryMapping("method01"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("b", "c", "()V"), new EntryMapping("method01"));
 
-		ValidationContext vc = new ValidationContext(notifier());
+		ValidationContext vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "a", "()V"), new EntryMapping("method01"));
 
 		assertMessages(vc, Message.SHADOWED_NAME_CLASS);
 
 		// private methods
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "a", "()V"), new EntryMapping("method02"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("b", "a", "()V"), new EntryMapping("method02"));
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "d", "()V"), new EntryMapping("method02"));
 
 		assertMessages(vc);
@@ -117,16 +117,16 @@ public class TestMappingValidator {
 
 	@RepeatedTest(value = 2, name = REPEATED_TEST_NAME)
 	public void nonUniqueFields() {
-		remapper.putMapping(newVC(), TestEntryFactory.newField("a", "a", "I"), new EntryMapping("field01"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newField("a", "a", "I"), new EntryMapping("field01"));
 
-		ValidationContext vc = new ValidationContext(notifier());
+		ValidationContext vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newField("a", "b", "I"), new EntryMapping("field01"));
 
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
 
-		remapper.putMapping(newVC(), TestEntryFactory.newField("a", "c", "Ljava/lang/String;"), new EntryMapping("FIELD_02"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newField("a", "c", "Ljava/lang/String;"), new EntryMapping("FIELD_02"));
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newField("a", "a", "Ljava/lang/String;"), new EntryMapping("FIELD_02"));
 
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
@@ -134,14 +134,14 @@ public class TestMappingValidator {
 
 	@RepeatedTest(value = 2, name = REPEATED_TEST_NAME)
 	public void nonUniqueMethods() {
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("a", "a", "()V"), new EntryMapping("method01"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("a", "a", "()V"), new EntryMapping("method01"));
 
-		ValidationContext vc = new ValidationContext(notifier());
+		ValidationContext vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "b", "()V"), new EntryMapping("method01"));
 
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "d", "()V"), new EntryMapping("method01"));
 
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
@@ -150,25 +150,25 @@ public class TestMappingValidator {
 	@RepeatedTest(value = 2, name = REPEATED_TEST_NAME)
 	public void conflictingMethods() {
 		// "overriding" w/different return descriptor
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "a", "()Z"), new EntryMapping("method01"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("b", "a", "()Z"), new EntryMapping("method01"));
 
-		ValidationContext vc = new ValidationContext(notifier());
+		ValidationContext vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "b", "()V"), new EntryMapping("method01"));
 
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
 
 		// "overriding" a static method
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "c", "()V"), new EntryMapping("method02"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("b", "c", "()V"), new EntryMapping("method02"));
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "b", "()V"), new EntryMapping("method02"));
 
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
 
 		// "overriding" when the original methods were not related
-		remapper.putMapping(newVC(), TestEntryFactory.newMethod("b", "b", "()I"), new EntryMapping("method03"));
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newMethod("b", "b", "()I"), new EntryMapping("method03"));
 
-		vc = new ValidationContext(notifier());
+		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "a", "()I"), new EntryMapping("method03"));
 
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
@@ -186,22 +186,5 @@ public class TestMappingValidator {
 			ParameterizedMessage msg = vc.getMessages().get(i);
 			assertThat(msg.message(), is(messages[i]));
 		}
-	}
-
-	private static ValidationContext newVC() {
-		return new ValidationContext(notifier());
-	}
-
-	private static ValidationContext.Notifier notifier() {
-		return new ValidationContext.Notifier() {
-			@Override
-			public void notify(ParameterizedMessage message) {
-			}
-
-			@Override
-			public boolean verifyWarning(ParameterizedMessage message) {
-				return true;
-			}
-		};
 	}
 }

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/TestUtil.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/TestUtil.java
@@ -1,5 +1,8 @@
 package org.quiltmc.enigma;
 
+import org.quiltmc.enigma.util.validation.ParameterizedMessage;
+import org.quiltmc.enigma.util.validation.ValidationContext;
+
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 
@@ -21,5 +24,22 @@ public final class TestUtil {
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	public static ValidationContext newVC() {
+		return new ValidationContext(notifier());
+	}
+
+	private static ValidationContext.Notifier notifier() {
+		return new ValidationContext.Notifier() {
+			@Override
+			public void notify(ParameterizedMessage message) {
+			}
+
+			@Override
+			public boolean verifyWarning(ParameterizedMessage message) {
+				return true;
+			}
+		};
 	}
 }


### PR DESCRIPTION
If two unrelated method declarations have the same name and descriptor, you can override both of them at the same time by extending their owners. If you renamed only one of these, the other one would either reset to the default impl or break during runtime.

With this pr, renames apply to both of them at the same time.