### PR TITLE
Document & test IndexEntryResolver

### DIFF
--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -20,6 +20,9 @@ dependencies {
 	proGuard libs.proguard
 
 	testImplementation libs.jimfs
+
+	testFixturesImplementation libs.asm
+	testFixturesImplementation libs.asm.tree
 }
 
 // Generate "version.txt" file

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/IndexEntryResolver.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/IndexEntryResolver.java
@@ -36,10 +36,11 @@ public class IndexEntryResolver implements EntryResolver {
 	}
 
 	/**
-	 * Resolves an entry, which may or may not exist in the bytecode, up to a matching entry definition, by traveling up
+	 * Resolves an entry, which may or may not exist in the bytecode, up to a matching entry definition, by travelling up
 	 * the class ancestry until finding the matching entry or entries. In most cases, this means converting something like
 	 * {@code ClassWithoutField#field} to {@code ClassWithField#field}, or {@code OverridingClass#toString} to
-	 * {@code Object#toString}. Only entries available in the index are returned.
+	 * {@code Object#toString}. Private and/or static entries are always resolved as the entry itself. Only entries
+	 * available in the index are returned. Matching entries are ones with the exact same name & descriptor.
 	 *
 	 * <p>
 	 * The {@code strategy} doesn't affect the result unless the entry is a {@linkplain MethodEntry} or a child of one,

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/IndexEntryResolver.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/IndexEntryResolver.java
@@ -71,15 +71,20 @@ public class IndexEntryResolver implements EntryResolver {
 				return Collections.singleton(entry);
 			}
 
+			// Don't search existing private and/or static entries up the hierarchy
 			// Fields and classes can't be redefined, don't search them up the hierarchy
 			if (access != null && (access.isPrivate() || access.isStatic() || entry instanceof FieldEntry || entry instanceof ClassEntry)) {
 				return Collections.singleton(entry);
-			} else if (access == null || (!access.isPrivate() && !access.isStatic())) {
+			} else {
+				// Search the entry up the hierarchy; if the entry exists we can skip static entries, since this one isn't static
 				Collection<Entry<ClassEntry>> resolvedChildren = this.resolveChildEntry(classChild, strategy, access != null);
 				if (!resolvedChildren.isEmpty()) {
 					return resolvedChildren.stream()
 						.map(resolvedChild -> (E) entry.replaceAncestor(classChild, resolvedChild))
 						.toList();
+				} else if (access == null) {
+					// No matching entry was found, and this one doesn't exist
+					return Collections.emptySet();
 				}
 			}
 		}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/IndexEntryResolver.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/IndexEntryResolver.java
@@ -35,6 +35,21 @@ public class IndexEntryResolver implements EntryResolver {
 		this.treeBuilder = new IndexTreeBuilder(index);
 	}
 
+	/**
+	 * Resolves an entry, which may or may not exist in the bytecode, up to a matching entry definition, by traveling up
+	 * the class ancestry until finding the matching entry or entries. In most cases, this means converting something like
+	 * {@code ClassWithoutField#field} to {@code ClassWithField#field}, or {@code OverridingClass#toString} to
+	 * {@code Object#toString}. Only entries available in the index are returned.
+	 *
+	 * <p>
+	 * The {@code strategy} doesn't affect the result unless the entry is a {@linkplain MethodEntry} or a child of one,
+	 * i.e. a {@linkplain org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntry LocalVariableEntry}.
+	 * Using {@link ResolutionStrategy#RESOLVE_CLOSEST}, the closest entry to {@code entry} in the hierarchy will be
+	 * returned, while using {@link ResolutionStrategy#RESOLVE_ROOT} will return the matching entries at the root(s) of
+	 * the hierarchy. This means, that overridden methods will be replaced by their highest possible definition, and if
+	 * the {@code entry} overrides multiple different methods at the same time, all the definitions of those methods
+	 * will be returned.
+	 */
 	@Override
 	@SuppressWarnings("unchecked")
 	public <E extends Entry<?>> Collection<E> resolveEntry(E entry, ResolutionStrategy strategy) {
@@ -55,8 +70,8 @@ public class IndexEntryResolver implements EntryResolver {
 				Collection<Entry<ClassEntry>> resolvedChildren = this.resolveChildEntry(classChild, strategy);
 				if (!resolvedChildren.isEmpty()) {
 					return resolvedChildren.stream()
-							.map(resolvedChild -> (E) entry.replaceAncestor(classChild, resolvedChild))
-							.toList();
+						.map(resolvedChild -> (E) entry.replaceAncestor(classChild, resolvedChild))
+						.toList();
 				}
 			}
 		}

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/analysis/index/IndexReferenceVisitor.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/analysis/index/IndexReferenceVisitor.java
@@ -59,7 +59,7 @@ public class IndexReferenceVisitor extends ClassVisitor {
 			try {
 				new Analyzer<>(new MethodInterpreter(entry, this.indexer, this.entryIndex, this.inheritanceIndex)).analyze(this.className, methodNode);
 			} catch (AnalyzerException e) {
-				throw new RuntimeException(e);
+				throw new RuntimeException("Failed to analyze " + methodNode.name, e);
 			}
 		});
 	}

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
@@ -1,0 +1,157 @@
+package org.quiltmc.enigma.translation.mapping;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.quiltmc.enigma.TestEntryFactory;
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
+import org.quiltmc.enigma.api.class_provider.ClassProvider;
+import org.quiltmc.enigma.api.translation.mapping.IndexEntryResolver;
+import org.quiltmc.enigma.api.translation.mapping.ResolutionStrategy;
+import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.test.bytecode.ClassNodeBuilder;
+import org.quiltmc.enigma.test.bytecode.MethodNodeBuilder;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class IndexEntryResolverTest {
+	private static final Map<String, ClassNode> CLASSES = new HashMap<>();
+	private static final ClassProvider CLASS_PROVIDER = new ClassProvider() {
+		@Nullable
+		@Override
+		public ClassNode get(String name) {
+			return CLASSES.get(name);
+		}
+
+		@Override
+		public Collection<String> getClassNames() {
+			return CLASSES.keySet();
+		}
+	};
+
+	private static JarIndex index;
+
+	private static IndexEntryResolver resolver;
+	@BeforeAll
+	public static void beforeAll() {
+		index = JarIndex.empty();
+		index.indexJar(new HashSet<>(CLASS_PROVIDER.getClassNames()), CLASS_PROVIDER, ProgressListener.createEmpty());
+		resolver = new IndexEntryResolver(index);
+	}
+
+	private static <E extends Entry<?>> void assertResolvedRoot(E entry, Collection<E> expected) {
+		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_ROOT));
+	}
+
+	private static <E extends Entry<?>> void assertResolvedClosest(E entry, Collection<E> expected) {
+		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_CLOSEST));
+	}
+
+	@Test
+	public void testResolveFields() {
+		var baseA = TestEntryFactory.newClass("BaseA");
+		var sub1A = TestEntryFactory.newClass("Sub1A");
+
+		var entry = TestEntryFactory.newField(sub1A, "field1", "Z");
+		var expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newField(baseA, "field1", "Z");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newField(sub1A, "field2", "I");
+		expected = TestEntryFactory.newField(baseA, "field2", "I");
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newField(sub1A, "field3", "I");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		// TODO: Non-existing entries should be resolved to empty or the entry singleton??
+		// entry = TestEntryFactory.newField(baseA, "field3", "I");
+
+		entry = TestEntryFactory.newField(sub1A, "field4", "J");
+		expected = TestEntryFactory.newField(baseA, "field4", "J");
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newField(sub1A, "field4", "B");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+	}
+
+	@Test
+	public void testResolveMethods() {
+		var baseB = TestEntryFactory.newClass("BaseB");
+		var sub1B = TestEntryFactory.newClass("Sub1B");
+		var sub1BSub1 = TestEntryFactory.newClass("Sub1BSub1");
+
+		var entry = TestEntryFactory.newMethod(baseB, "foo", "()LBaseB;");
+		var expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		// TODO
+	}
+
+	private static void clazz(ClassNode classNode) {
+		CLASSES.put(classNode.name, classNode);
+	}
+
+	static {
+		clazz(ClassNodeBuilder.create("BaseA")
+				.field("field1", "Z")
+				.field("field2", "I")
+				.field("field4", "J")
+				.superInit()
+				.build());
+		clazz(ClassNodeBuilder.create("Sub1A", "BaseA")
+				.field("field1", "Z")
+				.field("field3", "I")
+				.field("field4", "B")
+				.superInit()
+				.build());
+
+		clazz(ClassNodeBuilder.create("BaseB")
+				.superInit()
+				.method(MethodNodeBuilder.create("foo", "()LBaseB;")
+					.aload(0)
+					.insn(Opcodes.ARETURN)
+					.build())
+				.build());
+		clazz(ClassNodeBuilder.create("Sub1B", "BaseB")
+				.superInit()
+				.method(MethodNodeBuilder.create("foo", "()LSubB;")
+					.aload(0)
+					.insn(Opcodes.ARETURN)
+					.build())
+				.method(MethodNodeBuilder.create(Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC, "foo", "()LBaseB;", null, null)
+					.aload(0)
+					.methodInsn(Opcodes.INVOKEVIRTUAL, "Sub1B", "foo", "()LSubB;", false)
+					.insn(Opcodes.ARETURN)
+					.build())
+				.build());
+		clazz(ClassNodeBuilder.create("Sub1BSub1", "Sub1B")
+				.superInit()
+				.method(MethodNodeBuilder.create(Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC, "foo", "()LBaseB;", null, null)
+					.aload(0)
+					.methodInsn(Opcodes.INVOKESPECIAL, "Sub1B", "foo", "()LSubB;", false)
+					.insn(Opcodes.ARETURN)
+					.build())
+				.build());
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 public class IndexEntryResolverTest {
@@ -50,17 +51,19 @@ public class IndexEntryResolverTest {
 		resolver = new IndexEntryResolver(index);
 	}
 
-	private static <E extends Entry<?>> void assertResolvedRoot(E entry, Collection<E> expected) {
-		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_ROOT), "wrong root resolution of " + entry);
+	@SafeVarargs
+	private static <E extends Entry<?>> void assertResolvedRoot(E entry, E... expected) {
+		Assertions.assertIterableEquals(List.of(expected), resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_ROOT), "wrong root resolution of " + entry);
 	}
 
-	private static <E extends Entry<?>> void assertResolvedClosest(E entry, Collection<E> expected) {
-		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_CLOSEST), "wrong closest resolution of " + entry);
+	@SafeVarargs
+	private static <E extends Entry<?>> void assertResolvedClosest(E entry, E... expected) {
+		Assertions.assertIterableEquals(List.of(expected), resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_CLOSEST), "wrong closest resolution of " + entry);
 	}
 
 	private static <E extends Entry<?>> void assertResolvedSingle(E entry, E expected) {
-		assertResolvedRoot(entry, Collections.singleton(expected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolvedRoot(entry, expected);
+		assertResolvedClosest(entry, expected);
 	}
 
 	private static <E extends Entry<?>> void assertResolveIdentity(E entry) {
@@ -103,9 +106,7 @@ public class IndexEntryResolverTest {
 
 		// entry = TestEntryFactory.newField(baseA, "FIELD_9", "D");
 
-		entry = TestEntryFactory.newField(sub1A, "field13", "S");
-		expected = TestEntryFactory.newField(baseA, "field13", "S");
-		// assertResolvedSingle(entry, expected); // FIXME!
+		// entry = TestEntryFactory.newField(sub1A, "field13", "S");
 
 		// entry = TestEntryFactory.newField(baseA, "field14", "F");
 	}
@@ -135,22 +136,22 @@ public class IndexEntryResolverTest {
 
 		entry = TestEntryFactory.newMethod(sub1B, "foo", "()LBaseB;");
 		var expected = entry;
-		assertResolvedRoot(entry, Collections.singleton(baseExpected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolvedRoot(entry, baseExpected);
+		assertResolvedClosest(entry, expected);
 
 		entry = TestEntryFactory.newMethod(sub1B, "foo", "()LSub1B;");
 		expected = entry;
-		assertResolvedRoot(entry, Collections.singleton(baseExpected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolvedRoot(entry, baseExpected);
+		assertResolvedClosest(entry, expected);
 
 		entry = TestEntryFactory.newMethod(sub1BSub1, "foo", "()LSub1B;");
-		assertResolvedRoot(entry, Collections.singleton(baseExpected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolvedRoot(entry, baseExpected);
+		assertResolvedClosest(entry, expected);
 
 		entry = TestEntryFactory.newMethod(sub1BSub1, "foo", "()LBaseB;");
 		expected = entry;
-		assertResolvedRoot(entry, Collections.singleton(baseExpected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolvedRoot(entry, baseExpected);
+		assertResolvedClosest(entry, expected);
 
 		var baseC = TestEntryFactory.newClass("BaseC");
 		var sub1C = TestEntryFactory.newClass("Sub1C");
@@ -172,7 +173,7 @@ public class IndexEntryResolverTest {
 		assertResolveIdentity(entry);
 
 		entry = TestEntryFactory.newMethod(sub2C, "stat", "()LBaseC;");
-		// assertResolveIdentity(entry); // FIXME!
+		assertResolveIdentity(entry);
 	}
 
 	private static void clazz(ClassNode classNode) {

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
@@ -12,6 +12,7 @@ import org.quiltmc.enigma.api.class_provider.ClassProvider;
 import org.quiltmc.enigma.api.translation.mapping.IndexEntryResolver;
 import org.quiltmc.enigma.api.translation.mapping.ResolutionStrategy;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
 import org.quiltmc.enigma.test.bytecode.ClassNodeBuilder;
 import org.quiltmc.enigma.test.bytecode.MethodNodeBuilder;
 
@@ -48,11 +49,20 @@ public class IndexEntryResolverTest {
 	}
 
 	private static <E extends Entry<?>> void assertResolvedRoot(E entry, Collection<E> expected) {
-		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_ROOT));
+		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_ROOT), "wrong root resolution of " + entry);
 	}
 
 	private static <E extends Entry<?>> void assertResolvedClosest(E entry, Collection<E> expected) {
-		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_CLOSEST));
+		Assertions.assertIterableEquals(expected, resolver.resolveEntry(entry, ResolutionStrategy.RESOLVE_CLOSEST), "wrong closest resolution of " + entry);
+	}
+
+	private static <E extends Entry<?>> void assertResolvedSingle(E entry, E expected) {
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+	}
+
+	private static <E extends Entry<?>> void assertResolveIdentity(E entry) {
+		assertResolvedSingle(entry, entry);
 	}
 
 	@Test
@@ -61,37 +71,60 @@ public class IndexEntryResolverTest {
 		var sub1A = TestEntryFactory.newClass("Sub1A");
 
 		var entry = TestEntryFactory.newField(sub1A, "field1", "Z");
-		var expected = entry;
-		assertResolvedRoot(entry, Collections.singleton(expected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		// assertResolveIdentity(entry);
+		assertResolvedClosest(entry, Collections.singleton(entry));
 
 		entry = TestEntryFactory.newField(baseA, "field1", "Z");
-		expected = entry;
-		assertResolvedRoot(entry, Collections.singleton(expected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolveIdentity(entry);
 
 		entry = TestEntryFactory.newField(sub1A, "field2", "I");
-		expected = TestEntryFactory.newField(baseA, "field2", "I");
-		assertResolvedRoot(entry, Collections.singleton(expected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		var expected = TestEntryFactory.newField(baseA, "field2", "I");
+		assertResolvedSingle(entry, expected);
 
 		entry = TestEntryFactory.newField(sub1A, "field3", "I");
-		expected = entry;
-		assertResolvedRoot(entry, Collections.singleton(expected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolveIdentity(entry);
 
 		// TODO: Non-existing entries should be resolved to empty or the entry singleton??
 		// entry = TestEntryFactory.newField(baseA, "field3", "I");
 
 		entry = TestEntryFactory.newField(sub1A, "field4", "J");
 		expected = TestEntryFactory.newField(baseA, "field4", "J");
-		assertResolvedRoot(entry, Collections.singleton(expected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolvedSingle(entry, expected);
 
 		entry = TestEntryFactory.newField(sub1A, "field4", "B");
-		expected = entry;
-		assertResolvedRoot(entry, Collections.singleton(expected));
-		assertResolvedClosest(entry, Collections.singleton(expected));
+		assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "FIELD_5", "I");
+		assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "FIELD_6", "B");
+		// assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "FIELD_7", "C");
+		assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "FIELD_8", "D");
+		expected = TestEntryFactory.newField(baseA, "FIELD_8", "D");
+		assertResolvedSingle(entry, expected);
+
+		entry = TestEntryFactory.newField(sub1A, "FIELD_9", "D");
+		assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "field10", "Z");
+		assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "field11", "J");
+		assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "field12", "Ljava/lang/String;");
+		assertResolveIdentity(entry);
+
+		entry = TestEntryFactory.newField(sub1A, "field13", "S");
+		expected = TestEntryFactory.newField(baseA, "field13", "S");
+		// assertResolvedSingle(entry, expected);
+
+		entry = TestEntryFactory.newField(sub1A, "field14", "S");
+		assertResolveIdentity(entry);
 	}
 
 	@Test
@@ -101,11 +134,63 @@ public class IndexEntryResolverTest {
 		var sub1BSub1 = TestEntryFactory.newClass("Sub1BSub1");
 
 		var entry = TestEntryFactory.newMethod(baseB, "foo", "()LBaseB;");
-		var expected = entry;
+		var baseExpected = entry;
+		var expected = baseExpected;
 		assertResolvedRoot(entry, Collections.singleton(expected));
 		assertResolvedClosest(entry, Collections.singleton(expected));
 
-		// TODO
+		entry = TestEntryFactory.newMethod(sub1B, "foo", "()LBaseB;");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(baseExpected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(sub1B, "foo", "()LSub1B;");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(baseExpected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(sub1BSub1, "foo", "()LSub1B;");
+		assertResolvedRoot(entry, Collections.singleton(baseExpected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(sub1BSub1, "foo", "()LBaseB;");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(baseExpected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		var baseC = TestEntryFactory.newClass("BaseC");
+		var sub1C = TestEntryFactory.newClass("Sub1C");
+		var sub2C = TestEntryFactory.newClass("Sub2C");
+
+		entry = TestEntryFactory.newMethod(baseC, "priv", "()I");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(baseC, "stat", "()LBaseC;");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(sub1C, "priv", "()I");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(sub1C, "stat", "()LBaseC;");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(sub2C, "priv", "()I");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
+
+		entry = TestEntryFactory.newMethod(sub2C, "stat", "()LBaseC;");
+		expected = entry;
+		assertResolvedRoot(entry, Collections.singleton(expected));
+		assertResolvedClosest(entry, Collections.singleton(expected));
 	}
 
 	private static void clazz(ClassNode classNode) {
@@ -117,12 +202,28 @@ public class IndexEntryResolverTest {
 				.field("field1", "Z")
 				.field("field2", "I")
 				.field("field4", "J")
+				.field(Opcodes.ACC_STATIC, "FIELD_5", "I", null, null)
+				.field(Opcodes.ACC_STATIC, "FIELD_6", "B", null, null)
+				.field("FIELD_7", "C")
+				.field(Opcodes.ACC_STATIC, "FIELD_8", "D", null, null)
+				.field(Opcodes.ACC_PRIVATE, "field10", "Z", null, null)
+				.field(Opcodes.ACC_PRIVATE, "field11", "J", null, null)
+				.field("field12", "Ljava/lang/String;")
+				.field(Opcodes.ACC_PRIVATE, "field13", "S", null, null)
 				.superInit()
 				.build());
 		clazz(ClassNodeBuilder.create("Sub1A", "BaseA")
 				.field("field1", "Z")
 				.field("field3", "I")
 				.field("field4", "B")
+				.field(Opcodes.ACC_STATIC, "FIELD_5", "I", null, null)
+				.field("FIELD_6", "B")
+				.field(Opcodes.ACC_STATIC, "FIELD_7", "C", null, null)
+				.field(Opcodes.ACC_STATIC, "FIELD_9", "D", null, null)
+				.field(Opcodes.ACC_PRIVATE, "field10", "Z", null, null)
+				.field("field11", "J")
+				.field(Opcodes.ACC_PRIVATE, "field12", "Ljava/lang/String;", null, null)
+				.field(Opcodes.ACC_PRIVATE, "field14", "S", null, null)
 				.superInit()
 				.build());
 
@@ -135,13 +236,13 @@ public class IndexEntryResolverTest {
 				.build());
 		clazz(ClassNodeBuilder.create("Sub1B", "BaseB")
 				.superInit()
-				.method(MethodNodeBuilder.create("foo", "()LSubB;")
+				.method(MethodNodeBuilder.create("foo", "()LSub1B;")
 					.aload(0)
 					.insn(Opcodes.ARETURN)
 					.build())
 				.method(MethodNodeBuilder.create(Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC, "foo", "()LBaseB;", null, null)
 					.aload(0)
-					.methodInsn(Opcodes.INVOKEVIRTUAL, "Sub1B", "foo", "()LSubB;", false)
+					.methodInsn(Opcodes.INVOKEVIRTUAL, "Sub1B", "foo", "()LSub1B;", false)
 					.insn(Opcodes.ARETURN)
 					.build())
 				.build());
@@ -149,8 +250,50 @@ public class IndexEntryResolverTest {
 				.superInit()
 				.method(MethodNodeBuilder.create(Opcodes.ACC_BRIDGE | Opcodes.ACC_SYNTHETIC | Opcodes.ACC_PUBLIC, "foo", "()LBaseB;", null, null)
 					.aload(0)
-					.methodInsn(Opcodes.INVOKESPECIAL, "Sub1B", "foo", "()LSubB;", false)
+					.methodInsn(Opcodes.INVOKESPECIAL, "Sub1B", "foo", "()LSub1B;", false)
 					.insn(Opcodes.ARETURN)
+					.build())
+				.build());
+
+		clazz(ClassNodeBuilder.create("BaseC")
+				.superInit()
+				.method(MethodNodeBuilder.create(Opcodes.ACC_PRIVATE, "priv", "()I", null, null)
+					.iconst_0()
+					.insn(Opcodes.IRETURN)
+					.maxs(1, 1)
+					.build())
+				.method(MethodNodeBuilder.create(Opcodes.ACC_STATIC, "stat", "()LBaseC;", null, null)
+					.typeInsn(Opcodes.NEW, "BaseC")
+					.insn(Opcodes.DUP)
+					.methodInsn(Opcodes.INVOKESPECIAL, "BaseC", "<init>", "()V", false)
+					.insn(Opcodes.ARETURN)
+					.maxs(0, 2)
+					.build())
+				.build());
+		clazz(ClassNodeBuilder.create("Sub1C", "BaseC")
+				.superInit()
+				.method(MethodNodeBuilder.create(Opcodes.ACC_PRIVATE, "priv", "()I", null, null)
+					.iconst_0()
+					.insn(Opcodes.IRETURN)
+					.maxs(1, 1)
+					.build())
+				.method(MethodNodeBuilder.create(Opcodes.ACC_STATIC, "stat", "()LBaseC;", null, null)
+					.methodInsn(Opcodes.INVOKESTATIC, "BaseC", "stat", "()LBaseC;", false)
+					.insn(Opcodes.ARETURN)
+					.maxs(1, 1)
+					.build())
+				.build());
+		clazz(ClassNodeBuilder.create("Sub2C", "BaseC")
+				.superInit()
+				.method(MethodNodeBuilder.create("priv", "()I")
+					.iconst_0()
+					.insn(Opcodes.IRETURN)
+					.maxs(1, 1)
+					.build())
+				.method(MethodNodeBuilder.create("stat", "()LBaseC;")
+					.methodInsn(Opcodes.INVOKESTATIC, "Sub1C", "stat", "()LBaseC;", false)
+					.insn(Opcodes.ARETURN)
+					.maxs(1, 1)
 					.build())
 				.build());
 	}

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/TestEntryFactory.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/TestEntryFactory.java
@@ -7,7 +7,10 @@ import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 
-public class TestEntryFactory {
+public final class TestEntryFactory {
+	private TestEntryFactory() {
+	}
+
 	public static ClassEntry newClass(String name) {
 		return new ClassEntry(name);
 	}

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/ClassNodeBuilder.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/ClassNodeBuilder.java
@@ -30,8 +30,12 @@ public final class ClassNodeBuilder {
 		return this;
 	}
 
+	public ClassNodeBuilder field(int access, String name, String descriptor) {
+		return this.field(access, name, descriptor, null, null);
+	}
+
 	public ClassNodeBuilder field(String name, String descriptor) {
-		return this.field(Opcodes.ACC_PUBLIC, name, descriptor, null, null);
+		return this.field(Opcodes.ACC_PUBLIC, name, descriptor);
 	}
 
 	public ClassNodeBuilder method(MethodNode method) {

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/ClassNodeBuilder.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/ClassNodeBuilder.java
@@ -1,0 +1,55 @@
+package org.quiltmc.enigma.test.bytecode;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.quiltmc.enigma.api.Enigma;
+
+public final class ClassNodeBuilder {
+	private final ClassNode classNode;
+
+	private ClassNodeBuilder(int access, String name, String signature, String superName, String[] interfaces) {
+		this.classNode = new ClassNode(Enigma.ASM_VERSION);
+		this.classNode.visit(Opcodes.V1_8, access, name, signature, superName, interfaces);
+	}
+
+	public static ClassNodeBuilder create(int access, String name, String signature, String superName, String[] interfaces) {
+		return new ClassNodeBuilder(access, name, signature, superName, interfaces);
+	}
+
+	public static ClassNodeBuilder create(String name, String superName) {
+		return create(Opcodes.ACC_PUBLIC, name, null, superName, null);
+	}
+
+	public static ClassNodeBuilder create(String name) {
+		return create(name, "java/lang/Object");
+	}
+
+	public ClassNodeBuilder field(int access, String name, String descriptor, String signature, Object value) {
+		this.classNode.visitField(access, name, descriptor, signature, value);
+		return this;
+	}
+
+	public ClassNodeBuilder field(String name, String descriptor) {
+		return this.field(Opcodes.ACC_PUBLIC, name, descriptor, null, null);
+	}
+
+	public ClassNodeBuilder method(MethodNode method) {
+		method.accept(this.classNode);
+		return this;
+	}
+
+	public ClassNodeBuilder superInit() {
+		this.method(MethodNodeBuilder.create("<init>", "()V")
+				.aload(0)
+				.methodInsn(Opcodes.INVOKESPECIAL, this.classNode.superName, "<init>", "()V", false)
+				.insn(Opcodes.RETURN)
+				.maxs(1, 1)
+				.build());
+		return this;
+	}
+
+	public ClassNode build() {
+		return this.classNode;
+	}
+}

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/MethodNodeBuilder.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/MethodNodeBuilder.java
@@ -22,18 +22,28 @@ public final class MethodNodeBuilder {
 		return new MethodNodeBuilder(Opcodes.ACC_PUBLIC, name, descriptor, null, null);
 	}
 
+	public MethodNodeBuilder insn(int opcode) {
+		this.methodNode.visitInsn(opcode);
+		return this;
+	}
+
+	public MethodNodeBuilder iconst_0() {
+		this.methodNode.visitInsn(Opcodes.ICONST_0);
+		return this;
+	}
+
 	public MethodNodeBuilder aload(int var) {
 		this.methodNode.visitVarInsn(Opcodes.ALOAD, var);
 		return this;
 	}
 
-	public MethodNodeBuilder methodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
-		this.methodNode.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+	public MethodNodeBuilder typeInsn(int opcode, String type) {
+		this.methodNode.visitTypeInsn(opcode, type);
 		return this;
 	}
 
-	public MethodNodeBuilder insn(int opcode) {
-		this.methodNode.visitInsn(opcode);
+	public MethodNodeBuilder methodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+		this.methodNode.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
 		return this;
 	}
 

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/MethodNodeBuilder.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/MethodNodeBuilder.java
@@ -1,0 +1,50 @@
+package org.quiltmc.enigma.test.bytecode;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.MethodNode;
+import org.quiltmc.enigma.api.Enigma;
+
+public final class MethodNodeBuilder {
+	private final MethodNode methodNode;
+
+	private MethodNodeBuilder(int access, String name, String descriptor, String signature, String[] exceptions) {
+		this.methodNode = new MethodNode(Enigma.ASM_VERSION, access, name, descriptor, signature, exceptions);
+		this.methodNode.maxLocals = 10;
+		this.methodNode.maxStack = 10;
+		this.methodNode.visitCode();
+	}
+
+	public static MethodNodeBuilder create(int access, String name, String descriptor, String signature, String[] exceptions) {
+		return new MethodNodeBuilder(access, name, descriptor, signature, exceptions);
+	}
+
+	public static MethodNodeBuilder create(String name, String descriptor) {
+		return new MethodNodeBuilder(Opcodes.ACC_PUBLIC, name, descriptor, null, null);
+	}
+
+	public MethodNodeBuilder aload(int var) {
+		this.methodNode.visitVarInsn(Opcodes.ALOAD, var);
+		return this;
+	}
+
+	public MethodNodeBuilder methodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+		this.methodNode.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+		return this;
+	}
+
+	public MethodNodeBuilder insn(int opcode) {
+		this.methodNode.visitInsn(opcode);
+		return this;
+	}
+
+	public MethodNodeBuilder maxs(int maxLocals, int maxStack) {
+		this.methodNode.maxLocals = maxLocals;
+		this.methodNode.maxStack = maxStack;
+		return this;
+	}
+
+	public MethodNode build() {
+		this.methodNode.visitEnd();
+		return this.methodNode;
+	}
+}

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/MethodNodeBuilder.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/test/bytecode/MethodNodeBuilder.java
@@ -18,6 +18,10 @@ public final class MethodNodeBuilder {
 		return new MethodNodeBuilder(access, name, descriptor, signature, exceptions);
 	}
 
+	public static MethodNodeBuilder create(int access, String name, String descriptor) {
+		return new MethodNodeBuilder(access, name, descriptor, null, null);
+	}
+
 	public static MethodNodeBuilder create(String name, String descriptor) {
 		return new MethodNodeBuilder(Opcodes.ACC_PUBLIC, name, descriptor, null, null);
 	}


### PR DESCRIPTION
Adds tests and documents the main method of `IndexEntryResolver`, `#resolveEntry`. Fixes #202 