### PR TITLE
validate lambda parameters for uniqueness and add more tests

### DIFF
--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/JarIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/JarIndex.java
@@ -63,7 +63,8 @@ public class JarIndex implements JarIndexer {
 		BridgeMethodIndex bridgeMethodIndex = new BridgeMethodIndex(entryIndex, inheritanceIndex, referenceIndex);
 		PackageVisibilityIndex packageVisibilityIndex = new PackageVisibilityIndex();
 		EnclosingMethodIndex enclosingMethodIndex = new EnclosingMethodIndex();
-		return new JarIndex(entryIndex, inheritanceIndex, referenceIndex, bridgeMethodIndex, packageVisibilityIndex, enclosingMethodIndex);
+		LambdaIndex lambdaIndex = new LambdaIndex();
+		return new JarIndex(entryIndex, inheritanceIndex, referenceIndex, bridgeMethodIndex, packageVisibilityIndex, enclosingMethodIndex, lambdaIndex);
 	}
 
 	/**

--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/LambdaIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/LambdaIndex.java
@@ -1,24 +1,58 @@
 package org.quiltmc.enigma.api.analysis.index.jar;
 
+import com.google.common.collect.ImmutableListMultimap;
 import org.quiltmc.enigma.api.analysis.ReferenceTargetType;
 import org.quiltmc.enigma.api.translation.representation.Lambda;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodDefEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class LambdaIndex implements JarIndexer {
 	private final Map<MethodEntry, MethodDefEntry> callers = new HashMap<>();
+	private ImmutableListMultimap<MethodEntry, MethodEntry> lambdas = null;
+	private final ImmutableListMultimap.Builder<MethodEntry, MethodEntry> lambdasBuilder = ImmutableListMultimap.builder();
 
 	@Override
 	public void indexLambda(MethodDefEntry callerEntry, Lambda lambda, ReferenceTargetType targetType) {
 		MethodEntry implMethod = (MethodEntry) lambda.implMethod();
 		this.callers.put(implMethod, callerEntry);
+
+		this.lambdasBuilder.put(callerEntry, implMethod);
+	}
+
+	@Override
+	public void processIndex(JarIndex index) {
+		var nestedLambdas = this.lambdasBuilder.build();
+
+		// denest
+		ImmutableListMultimap.Builder<MethodEntry, MethodEntry> topLevelLambdasBuilder = ImmutableListMultimap.builder();
+		for (var callerMethod : nestedLambdas.keySet()) {
+			// if caller method is a lambda itself, find the top level method
+			boolean isLambda = nestedLambdas.containsValue(callerMethod);
+			MethodEntry topLevel = callerMethod;
+
+			while (isLambda) {
+				topLevel = this.callers.get(topLevel);
+				isLambda = nestedLambdas.containsValue(topLevel);
+			}
+
+			topLevelLambdasBuilder.put(topLevel, callerMethod);
+		}
+
+		this.lambdas = topLevelLambdasBuilder.build();
 	}
 
 	public MethodDefEntry getCaller(MethodEntry lambda) {
 		return this.callers.get(lambda);
+	}
+
+	@Nullable
+	public List<MethodEntry> getInternalLambdas(MethodEntry caller) {
+		return this.lambdas.get(caller);
 	}
 
 	@Override

--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/LambdaIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/LambdaIndex.java
@@ -1,0 +1,28 @@
+package org.quiltmc.enigma.api.analysis.index.jar;
+
+import org.quiltmc.enigma.api.analysis.ReferenceTargetType;
+import org.quiltmc.enigma.api.translation.representation.Lambda;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodDefEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LambdaIndex implements JarIndexer {
+	private final Map<MethodEntry, MethodDefEntry> callers = new HashMap<>();
+
+	@Override
+	public void indexLambda(MethodDefEntry callerEntry, Lambda lambda, ReferenceTargetType targetType) {
+		MethodEntry implMethod = (MethodEntry) lambda.implMethod();
+		this.callers.put(implMethod, callerEntry);
+	}
+
+	public MethodDefEntry getCaller(MethodEntry lambda) {
+		return this.callers.get(lambda);
+	}
+
+	@Override
+	public String getTranslationKey() {
+		return "progress.jar.indexing.process.lambdas";
+	}
+}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/MappingValidator.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/MappingValidator.java
@@ -130,7 +130,10 @@ public class MappingValidator {
 		MethodEntry parent = parameter.getParent();
 		if (parent != null) {
 			var entryIndex = this.jarIndex.getIndex(EntryIndex.class);
+			var lambdaIndex = this.jarIndex.getIndex(LambdaIndex.class);
+			var parameters = parent.getParameters(entryIndex);
 
+			// add parent parameters for lambdas
 			Optional<MethodEntry> lambdaParentMethod = this.getLambdaParentMethod(parent);
 			List<MethodEntry> lambdaParents = new ArrayList<>();
 			while (lambdaParentMethod.isPresent()) {
@@ -138,9 +141,14 @@ public class MappingValidator {
 				lambdaParentMethod = this.getLambdaParentMethod(lambdaParentMethod.get());
 			}
 
-			var parameters = parent.getParameters(entryIndex);
 			if (!lambdaParents.isEmpty()) {
 				parameters.addAll(lambdaParents.stream().flatMap(m -> m.getParameters(entryIndex).stream()).toList());
+			}
+
+			// add nested lambda parents for normal methods
+			List<MethodEntry> internalLambdas = lambdaIndex.getInternalLambdas(parent);
+			if (internalLambdas != null) {
+				parameters.addAll(internalLambdas.stream().flatMap(m -> m.getParameters(entryIndex).stream()).toList());
 			}
 
 			for (LocalVariableEntry arg : parameters) {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/MappingValidator.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/MappingValidator.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.api.translation.mapping;
 
-import org.quiltmc.enigma.api.analysis.index.jar.EnclosingMethodIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.EntryIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.InheritanceIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
@@ -21,10 +20,8 @@ import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/Lambda.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/Lambda.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 public record Lambda(String invokedName, MethodDescriptor invokedType, MethodDescriptor samMethodType, ParentedEntry<?> implMethod, MethodDescriptor instantiatedMethodType) implements Translatable {
 	@Override
 	public TranslateResult<Lambda> extendedTranslate(Translator translator, EntryResolver resolver, EntryMap<EntryMapping> mappings) {
-		MethodEntry samMethod = new MethodEntry(this.getInterface(), this.invokedName, this.samMethodType);
+		MethodEntry samMethod = this.toSamMethod();
 		EntryMapping samMethodMapping = this.resolveMapping(resolver, mappings, samMethod);
 
 		return TranslateResult.of(
@@ -45,6 +45,10 @@ public record Lambda(String invokedName, MethodDescriptor invokedType, MethodDes
 
 	public ClassEntry getInterface() {
 		return this.invokedType.getReturnDesc().getTypeEntry();
+	}
+
+	public MethodEntry toSamMethod() {
+		return new MethodEntry(this.getInterface(), this.invokedName, this.samMethodType);
 	}
 
 	@Override

--- a/enigma/src/test/java/org/quiltmc/enigma/TestInnerClassParameterStats.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TestInnerClassParameterStats.java
@@ -19,14 +19,18 @@ import static org.hamcrest.Matchers.equalTo;
 public class TestInnerClassParameterStats {
 	private static final Path JAR = TestUtil.obfJar("inner_classes");
 
+	/**
+	 * Note: this test will break when parameters are added/removed from any input in the {@code inner_classes} package or the {@code Keep} class.
+	 * This is ok! Simply change the assertions for the new values.
+	 */
 	@Test
 	public void testInnerClassParameterStats() {
 		EnigmaProject project = openProject();
 		ProjectStatsResult stats = new StatsGenerator(project).generate(ProgressListener.createEmpty(), EnumSet.of(StatType.PARAMETERS), null, false);
-		// 5/8 total parameters in our six classes are non-mappable, meaning that we should get 0/3 parameters mapped
+		// 8/13 total parameters in our six classes are non-mappable, meaning that we should get 0/3 parameters mapped
 		// these non-mappable parameters come from non-static inner classes taking their enclosing class as a parameter
 		// they are currently manually excluded by a check in the stats generator
-		assertThat(stats.getMappable(StatType.PARAMETERS), equalTo(3));
+		assertThat(stats.getMappable(StatType.PARAMETERS), equalTo(5));
 		assertThat(stats.getMapped(StatType.PARAMETERS), equalTo(0));
 	}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
@@ -8,7 +8,10 @@ public class Keep {
 	}
 
 	public static void main(String g) {
-		gaming((s) -> System.out.println(s));
+		gaming((s) -> {
+			System.out.println(s);
+			gaming((q) -> System.out.println(q));
+		});
 	}
 
 	public static void gaming(Consumer<String> runnable) {

--- a/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
@@ -1,7 +1,17 @@
 package org.quiltmc.enigma.input;
 
+import java.util.function.Consumer;
+
 public class Keep {
 	public static void main(String... args) {
 		System.out.println("Keep me!");
+	}
+
+	public static void main(String g) {
+		gaming((s) -> System.out.println(s));
+	}
+
+	public static void gaming(Consumer<String> runnable) {
+		runnable.accept("Gaming!");
 	}
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
@@ -1,20 +1,7 @@
 package org.quiltmc.enigma.input;
 
-import java.util.function.Consumer;
-
 public class Keep {
 	public static void main(String... args) {
 		System.out.println("Keep me!");
-	}
-
-	public static void main(String g) {
-		gaming((s) -> {
-			System.out.println(s);
-			gaming((q) -> System.out.println(q));
-		});
-	}
-
-	public static void gaming(Consumer<String> runnable) {
-		runnable.accept("Gaming!");
 	}
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/input/inner_classes/NestedLambdas.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/inner_classes/NestedLambdas.java
@@ -1,0 +1,16 @@
+package org.quiltmc.enigma.input.inner_classes;
+
+import java.util.function.Consumer;
+
+public class NestedLambdas {
+	public static void main(String g) {
+		gaming((s) -> gaming((w) -> {
+			System.out.println(s);
+			gaming(System.out::println);
+		}));
+	}
+
+	public static void gaming(Consumer<String> runnable) {
+		runnable.accept("Gaming!");
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/validation/BaseClass.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/validation/BaseClass.java
@@ -34,4 +34,9 @@ public class BaseClass extends SuperClass {
 	public int methodF() {
 		return 1;
 	}
+
+	// a(II)I
+	public int methodG(int a, int b) {
+		return a + b;
+	}
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidator.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidator.java
@@ -9,6 +9,7 @@ import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
 import org.quiltmc.enigma.api.translation.mapping.tree.HashEntryTree;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.util.validation.Message;
 import org.quiltmc.enigma.util.validation.ParameterizedMessage;
 import org.quiltmc.enigma.util.validation.ValidationContext;
@@ -171,6 +172,23 @@ public class TestMappingValidator {
 		vc = TestUtil.newVC();
 		remapper.validatePutMapping(vc, TestEntryFactory.newMethod("a", "a", "()I"), new EntryMapping("method03"));
 
+		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
+	}
+
+	@RepeatedTest(value = 2, name = REPEATED_TEST_NAME)
+	public void testParameterNames() {
+		MethodEntry method = TestEntryFactory.newMethod("a", "a", "(II)I");
+
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newParameter(method, 1), new EntryMapping("param01"));
+
+		ValidationContext vc = TestUtil.newVC();
+		remapper.validatePutMapping(vc, TestEntryFactory.newParameter(method, 2), new EntryMapping("param01"));
+		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
+
+		remapper.putMapping(TestUtil.newVC(), TestEntryFactory.newParameter(method, 2), new EntryMapping("param02"));
+
+		vc = TestUtil.newVC();
+		remapper.validatePutMapping(vc, TestEntryFactory.newParameter(method, 1), new EntryMapping("param02"));
 		assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
 	}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidator.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidator.java
@@ -180,7 +180,7 @@ public class TestMappingValidator {
 	 * @param vc validation context
 	 * @param messages the messages the validation context should contain
 	 */
-	private static void assertMessages(ValidationContext vc, Message... messages) {
+	public static void assertMessages(ValidationContext vc, Message... messages) {
 		assertThat(vc.getMessages().size(), is(messages.length));
 		for (int i = 0; i < messages.length; i++) {
 			ParameterizedMessage msg = vc.getMessages().get(i);

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
@@ -66,7 +66,11 @@ public class TestMappingValidatorParameters {
 		remapper.validatePutMapping(vc5, parentParam, new EntryMapping("LEVEL_1"));
 		TestMappingValidator.assertMessages(vc5, Message.NON_UNIQUE_NAME_CLASS);
 
-		// todo validate nested lambda name conflict with nested-er lambda
+		// validate nested lambda name conflict with nested-er lambda
+
+		ValidationContext vc6 = TestUtil.newVC();
+		remapper.validatePutMapping(vc6, firstLambdaParam, new EntryMapping("LEVEL_2"));
+		TestMappingValidator.assertMessages(vc6, Message.NON_UNIQUE_NAME_CLASS);
 	}
 
 	@Test

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
@@ -19,13 +19,12 @@ import java.nio.file.Path;
 
 public class TestMappingValidatorParameters {
 	public static final Path JAR = TestUtil.obfJar("inner_classes");
-	private static EnigmaProject project;
 	private static EntryRemapper remapper;
 
 	@BeforeAll
 	public static void beforeAll() throws Exception {
 		Enigma enigma = Enigma.create();
-		project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+		EnigmaProject project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
 		remapper = project.getRemapper();
 	}
 
@@ -59,7 +58,15 @@ public class TestMappingValidatorParameters {
 		// validate parent parameter name conflict with top level lambda and nested lambda
 		remapper.putMapping(TestUtil.newVC(), secondLambdaParam, new EntryMapping("LEVEL_2"));
 
-		// TODO
+		ValidationContext vc4 = TestUtil.newVC();
+		remapper.validatePutMapping(vc4, parentParam, new EntryMapping("LEVEL_2"));
+		TestMappingValidator.assertMessages(vc4, Message.NON_UNIQUE_NAME_CLASS);
+
+		ValidationContext vc5 = TestUtil.newVC();
+		remapper.validatePutMapping(vc5, parentParam, new EntryMapping("LEVEL_1"));
+		TestMappingValidator.assertMessages(vc5, Message.NON_UNIQUE_NAME_CLASS);
+
+		// todo validate nested lambda name conflict with nested-er lambda
 	}
 
 	@Test

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
@@ -1,0 +1,69 @@
+package org.quiltmc.enigma.translation.mapping;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.enigma.TestEntryFactory;
+import org.quiltmc.enigma.TestUtil;
+import org.quiltmc.enigma.api.Enigma;
+import org.quiltmc.enigma.api.EnigmaProject;
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
+import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
+import org.quiltmc.enigma.util.validation.Message;
+import org.quiltmc.enigma.util.validation.ValidationContext;
+
+import java.nio.file.Path;
+
+public class TestMappingValidatorParameters {
+	public static final Path JAR = TestUtil.obfJar("inner_classes");
+	private static EnigmaProject project;
+	private static EntryRemapper remapper;
+
+	@BeforeAll
+	public static void beforeAll() throws Exception {
+		Enigma enigma = Enigma.create();
+		project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+		remapper = project.getRemapper();
+	}
+
+	@Test
+	public void testLambdaParameterNames() {
+		MethodEntry parent = TestEntryFactory.newMethod("g", "a", "(Ljava/lang/String;)V");
+		LocalVariableEntry parentParam = TestEntryFactory.newParameter(parent, 0);
+		MethodEntry firstLambda = TestEntryFactory.newMethod("g", "b", "(Ljava/lang/String;)V");
+		LocalVariableEntry firstLambdaParam = TestEntryFactory.newParameter(firstLambda, 0);
+		MethodEntry secondLambda = TestEntryFactory.newMethod("g", "a", "(Ljava/lang/String;Ljava/lang/String;)V");
+		LocalVariableEntry secondLambdaParam = TestEntryFactory.newParameter(secondLambda, 1);
+
+		// validate conflict with base method
+		remapper.putMapping(TestUtil.newVC(), parentParam, new EntryMapping("LEVEL_0"));
+
+		ValidationContext vc = TestUtil.newVC();
+		remapper.validatePutMapping(vc, firstLambdaParam, new EntryMapping("LEVEL_0"));
+		TestMappingValidator.assertMessages(vc, Message.NON_UNIQUE_NAME_CLASS);
+
+		ValidationContext vc2 = TestUtil.newVC();
+		remapper.validatePutMapping(vc2, secondLambdaParam, new EntryMapping("LEVEL_0"));
+		TestMappingValidator.assertMessages(vc2, Message.NON_UNIQUE_NAME_CLASS);
+
+		// validate nested lambda conflict with top level lambda
+		remapper.putMapping(TestUtil.newVC(), firstLambdaParam, new EntryMapping("LEVEL_1"));
+
+		ValidationContext vc3 = TestUtil.newVC();
+		remapper.validatePutMapping(vc3, secondLambdaParam, new EntryMapping("LEVEL_1"));
+		TestMappingValidator.assertMessages(vc3, Message.NON_UNIQUE_NAME_CLASS);
+
+		// validate parent parameter name conflict with top level lambda and nested lambda
+		remapper.putMapping(TestUtil.newVC(), secondLambdaParam, new EntryMapping("LEVEL_2"));
+
+		// TODO
+	}
+
+	@Test
+	public void testParameterNames() {
+		// TODO test normal param conflicts
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMappingValidatorParameters.java
@@ -72,9 +72,4 @@ public class TestMappingValidatorParameters {
 		remapper.validatePutMapping(vc6, firstLambdaParam, new EntryMapping("LEVEL_2"));
 		TestMappingValidator.assertMessages(vc6, Message.NON_UNIQUE_NAME_CLASS);
 	}
-
-	@Test
-	public void testParameterNames() {
-		// TODO test normal param conflicts
-	}
 }

--- a/enigma/src/testFixtures/java/org/quiltmc/enigma/TestEntryFactory.java
+++ b/enigma/src/testFixtures/java/org/quiltmc/enigma/TestEntryFactory.java
@@ -5,6 +5,7 @@ import org.quiltmc.enigma.api.translation.representation.MethodDescriptor;
 import org.quiltmc.enigma.api.translation.representation.TypeDescriptor;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 
 public class TestEntryFactory {
@@ -26,6 +27,10 @@ public class TestEntryFactory {
 
 	public static MethodEntry newMethod(ClassEntry classEntry, String methodName, String methodSignature) {
 		return new MethodEntry(classEntry, methodName, new MethodDescriptor(methodSignature));
+	}
+
+	public static LocalVariableEntry newParameter(MethodEntry parent, int index) {
+		return new LocalVariableEntry(parent, index);
 	}
 
 	public static EntryReference<FieldEntry, MethodEntry> newFieldReferenceByMethod(FieldEntry fieldEntry, String callerClassName, String callerName, String callerSignature) {


### PR DESCRIPTION
adds lambdas into the mix for parameter uniqueness validation.

known issues:
- ~~names are not checked into lambdas (renaming a parameter of a top level method into a conflict with a parameter of an enclosed method will not throw an error)~~

fixes #188 