### PR TITLE
Fix (most) scaling

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/Theme.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/Theme.java
@@ -41,8 +41,8 @@ public class Theme extends ReflectiveConfig {
 		this.properties.configure();
 	}
 
-	public boolean needsScaling() {
-		return this.properties.needsScaling();
+	public boolean onlyScaleFonts() {
+		return this.properties.onlyScaleFonts();
 	}
 
 	public static class Fonts extends Section {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/ConfigurableFlatLafThemeProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/ConfigurableFlatLafThemeProperties.java
@@ -16,7 +16,7 @@ public abstract class ConfigurableFlatLafThemeProperties extends ConfigurableLaf
 	}
 
 	@Override
-	public final boolean needsScaling() {
-		return false;
+	public final boolean onlyScaleFonts() {
+		return true;
 	}
 }

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/MetalThemeProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/MetalThemeProperties.java
@@ -21,8 +21,8 @@ public class MetalThemeProperties extends NonConfigurableLafThemeProperties {
 	}
 
 	@Override
-	public boolean needsScaling() {
-		return true;
+	public boolean onlyScaleFonts() {
+		return false;
 	}
 
 	@Override

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/NoneThemeProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/NoneThemeProperties.java
@@ -23,8 +23,8 @@ public class NoneThemeProperties extends NonConfigurableLafThemeProperties {
 	}
 
 	@Override
-	public boolean needsScaling() {
-		return true;
+	public boolean onlyScaleFonts() {
+		return false;
 	}
 
 	@Override

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/SystemThemeProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/SystemThemeProperties.java
@@ -34,7 +34,7 @@ public class SystemThemeProperties extends ThemeProperties {
 	}
 
 	@Override
-	public boolean needsScaling() {
-		return true;
+	public boolean onlyScaleFonts() {
+		return false;
 	}
 }

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/ThemeProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/ThemeProperties.java
@@ -33,7 +33,7 @@ public abstract class ThemeProperties extends CompositeConfigCreator {
 
 	// FlatLaf-based LaFs do their own scaling so we don't have to do it.
 	// Running swing-dpi for FlatLaf actually breaks fonts, so we let it scale the GUI.
-	public abstract boolean needsScaling();
+	public abstract boolean onlyScaleFonts();
 
 	public static class SerializableColor extends Color implements ConfigSerializableObject<String> {
 		public static void addFormatComment(Comment.Builder comment) {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/ThemeProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/ThemeProperties.java
@@ -31,7 +31,7 @@ public abstract class ThemeProperties extends CompositeConfigCreator {
 			UnsupportedLookAndFeelException, ClassNotFoundException,
 			InstantiationException, IllegalAccessException;
 
-	// FlatLaf-based LaFs do their own scaling so we don't have to do it.
+	// FlatLaf-based LaFs do (some of) their own scaling so we don't have to do (all of) it.
 	// Running swing-dpi for FlatLaf actually breaks fonts, so we let it scale the GUI.
 	public abstract boolean onlyScaleFonts();
 

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/docker/component/DockerButton.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/docker/component/DockerButton.java
@@ -12,9 +12,12 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.event.MouseEvent;
+import java.awt.geom.Rectangle2D;
 import java.util.function.Supplier;
 
 public class DockerButton extends JToggleButton implements Draggable {
+	private static final int PAD_FACTOR = 10;
+
 	private final Docker docker;
 
 	private JComponent initialParent;
@@ -132,10 +135,15 @@ public class DockerButton extends JToggleButton implements Draggable {
 		g2d.setFont(font);
 
 		// position
-		int textSize = (int) font.createGlyphVector(g2d.getFontRenderContext(), translatedText).getVisualBounds().getWidth() + ScaleUtil.scale(20);
-		this.setPreferredSize(new Dimension(this.getPreferredSize().width, textSize));
-		int x = this.side == Docker.Side.RIGHT ? ScaleUtil.scale(10) : -textSize + ScaleUtil.scale(10);
-		int y = this.side == Docker.Side.RIGHT ? -ScaleUtil.scale(10) : ScaleUtil.scale(20);
+		final int scaledPadding = ScaleUtil.scale(PAD_FACTOR);
+		final int doubleScaledPadding = scaledPadding * 2;
+
+		final Rectangle2D textBounds = font.createGlyphVector(g2d.getFontRenderContext(), translatedText).getVisualBounds();
+		final int paddedTextWidth = (int) textBounds.getWidth() + doubleScaledPadding;
+		final int paddedTextHeight = (int) textBounds.getHeight() + doubleScaledPadding;
+		this.setPreferredSize(new Dimension(paddedTextHeight, paddedTextWidth));
+		int x = this.side == Docker.Side.RIGHT ? scaledPadding : -paddedTextWidth + scaledPadding;
+		int y = this.side == Docker.Side.RIGHT ? -scaledPadding : paddedTextHeight - scaledPadding;
 
 		g2d.drawString(translatedText, x, y);
 		this.setSize(this.getPreferredSize());

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
@@ -96,12 +96,12 @@ public class ScaleUtil {
 		for (Object key: Collections.list(defaults.keys())) {
 			final Object original = defaults.get(key);
 
-			final Object newValue = original instanceof Font font
-					? tweaker.modifyFont(key, font)
-					: original;
+			if (original instanceof Font originalFont) {
+				final Font modifiedFont = tweaker.modifyFont(key, originalFont);
 
-			if (newValue != null && newValue != original) {
-				defaults.put(key, newValue);
+				if (modifiedFont != null && modifiedFont != originalFont) {
+					defaults.put(key, modifiedFont);
+				}
 			}
 		}
 	}

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
@@ -17,8 +17,8 @@ import java.util.List;
 import java.util.function.Function;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
+import javax.swing.UIDefaults;
 import javax.swing.UIManager;
-import javax.swing.*;
 import javax.swing.border.Border;
 
 public class ScaleUtil {
@@ -90,14 +90,13 @@ public class ScaleUtil {
 
 	// effectively UiDefaultsScaler::modifyDefaults but only for fonts
 	private static void scaleFontsOnly(float scale) {
-		UIDefaults defaults = UIManager.getLookAndFeelDefaults();
+		final UIDefaults defaults = UIManager.getLookAndFeelDefaults();
 
 		final BasicTweaker tweaker = new BasicTweaker(scale);
 		for (Object key: Collections.list(defaults.keys())) {
-			Object original = defaults.get(key);
+			final Object original = defaults.get(key);
 
-			final Object newValue =
-				original instanceof Font font
+			final Object newValue = original instanceof Font font
 					? tweaker.modifyFont(key, font)
 					: original;
 
@@ -128,8 +127,8 @@ public class ScaleUtil {
 	private static class DelegatingEnsuredFontScalingBasicTweaker extends BasicTweaker {
 		private final BasicTweaker delegate;
 
-		public DelegatingEnsuredFontScalingBasicTweaker(
-			float scaleFactor, Function<Float, BasicTweaker> delegateFactory
+		DelegatingEnsuredFontScalingBasicTweaker(
+				float scaleFactor, Function<Float, BasicTweaker> delegateFactory
 		) {
 			super(scaleFactor);
 			this.delegate = delegateFactory.apply(scaleFactor);

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
@@ -79,9 +79,8 @@ public class ScaleUtil {
 			UiDefaultsScaler.updateAndApplyGlobalScaling((int) (100 * scale), true);
 		}
 
-		Font font = Config.currentFonts().editor.value();
-		font = font.deriveFont((float) (12 * scale));
-		SyntaxpainConfiguration.setEditorFont(font);
+		final Font font = SyntaxpainConfiguration.getEditorFont();
+		SyntaxpainConfiguration.setEditorFont(font.deriveFont((float) (font.getSize() * scale)));
 	}
 
 	@SuppressWarnings("null")

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/util/ScaleUtil.java
@@ -5,9 +5,7 @@ import com.github.swingdpi.plaf.BasicTweaker;
 import com.github.swingdpi.plaf.MetalTweaker;
 import com.github.swingdpi.plaf.NimbusTweaker;
 import com.github.swingdpi.plaf.WindowsTweaker;
-import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.enigma.gui.config.Config;
-import org.quiltmc.enigma.gui.config.theme.Theme;
 import org.quiltmc.syntaxpain.SyntaxpainConfiguration;
 
 import java.awt.Dimension;
@@ -27,10 +25,6 @@ public class ScaleUtil {
 		float oldScale = Config.main().scaleFactor.value();
 		float clamped = Math.min(Math.max(0.25f, scaleFactor), 10.0f);
 		Config.main().scaleFactor.setValue(clamped, true);
-		rescaleFontInConfig(Config.currentFonts().defaultBold, oldScale);
-		rescaleFontInConfig(Config.currentFonts().defaultNormal, oldScale);
-		rescaleFontInConfig(Config.currentFonts().small, oldScale);
-		rescaleFontInConfig(Config.currentFonts().editor, oldScale);
 		listeners.forEach(l -> l.onScaleChanged(clamped, oldScale));
 	}
 
@@ -56,16 +50,6 @@ public class ScaleUtil {
 
 	public static Font scaleFont(Font font) {
 		return createTweakerForCurrentLook(Config.main().scaleFactor.value()).modifyFont("", font);
-	}
-
-	private static void rescaleFontInConfig(TrackedValue<Theme.Fonts.SerializableFont> font, float oldScale) {
-		font.setValue(new Theme.Fonts.SerializableFont(rescaleFont(font.value(), oldScale)), true);
-	}
-
-	// This does not use the font that's currently active in the UI!
-	private static Font rescaleFont(Font font, float oldScale) {
-		float newSize = Math.round(font.getSize() / oldScale * Config.main().scaleFactor.value());
-		return font.deriveFont(newSize);
 	}
 
 	public static float scale(float f) {


### PR DESCRIPTION
### Removes `ScaleUtil::rescaleFontInConfig`
It scaled fonts in addition to `ScaleUtil::scaleFont`, and it didn't account for switching themes. If you increased scale on one theme, its fonts would be scaled to match. But if you switched themes, the previous theme would keep its scaled fonts and the new theme would not have scaled themes. If you then decreased scale on the new theme, it fonts would be scaled down (and they'd never been scaled up because the scale increase happened on another theme).

This makes the font sizes in theme configs 'base' sizes before main.toml's scale is applied.

### Fixes Theme's editor font size getting overwritten (and being read twice)
It was read and set first in `Config::updateSyntaxpain`.
Then it was read again in `ScaleUtil::applyScaling` and its size was explicitly set to 12 and scaled with main.toml's scale.

Now its read in `Config::updateSyntaxpain`, and `ScaleUtil::applyScaling` gets the syntaxpain's current font (already set from config), gets its size, and scales it with main.toml's scale.

### Fixes `DockerButton` scaled size+position for flatlaf themes
Broken since #216 (oops).
Buttons were already manually scaled+positioned to account for text width, I just added the same thing for text height.

### Fixes icon scaling for flatlaf themes
Also broken since #216 (oops).
Instead of skipping all scaling for flatlaf themes in `ScaleUtil::applyScaling`, they now have their fonts scaled.