### PR TITLE
Fix incorrect save location when saving from the save before close dialog

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/Gui.java
@@ -488,7 +488,9 @@ public class Gui {
 	public CompletableFuture<Void> saveMapping() {
 		ExtensionFileFilter.setupFileChooser(this.getController().getGui(), this.mappingsFileChooser, this.controller.getReadWriteService());
 
-		if (this.mappingsFileChooser.getSelectedFile() != null || this.mappingsFileChooser.showSaveDialog(this.mainWindow.getFrame()) == JFileChooser.APPROVE_OPTION) {
+		if (this.mappingsFileChooser.getSelectedFile() != null) {
+			return this.controller.saveMappings(this.mappingsFileChooser.getSelectedFile().toPath());
+		} else if (this.mappingsFileChooser.showSaveDialog(this.mainWindow.getFrame()) == JFileChooser.APPROVE_OPTION) {
 			return this.controller.saveMappings(ExtensionFileFilter.getSavePath(this.mappingsFileChooser));
 		}
 


### PR DESCRIPTION
If you save from the dialog that comes up when attempting to close with unsaved mappings, they sometimes save in the incorrect location. This fixes that