### PR TITLE
add `ProjectClassProvider`

### DIFF
--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -10,6 +10,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.class_provider.CachingClassProvider;
 import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.MappingDelta;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingParseException;
@@ -108,7 +109,7 @@ public abstract class Command {
 		Logger.info("Reading JAR...");
 		JarClassProvider classProvider = new JarClassProvider(jar);
 		JarIndex index = MainJarIndex.empty();
-		index.indexJar(classProvider.getClassNames(), new CachingClassProvider(classProvider), ProgressListener.createEmpty());
+		index.indexJar(new ProjectClassProvider(new CachingClassProvider(classProvider), null), ProgressListener.createEmpty());
 
 		return index;
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
@@ -89,6 +89,9 @@ public class Enigma {
 		// main index
 		this.index(index, projectClassProvider, progress);
 
+		// lib index
+		this.index(libIndex, projectClassProvider, progress);
+
 		// name proposal
 		var nameProposalServices = this.getNameProposalServices();
 		progress.init(nameProposalServices.size(), I18n.translate("progress.jar.name_proposal"));
@@ -127,8 +130,10 @@ public class Enigma {
 
 		int i = 1;
 		for (var service : indexers) {
-			progress.step(i++, I18n.translateFormatted("progress.jar.custom_indexing.indexer", service.getId()));
-			service.acceptJar(classProvider, index);
+			if (!(index instanceof LibrariesJarIndex && !service.shouldIndexLibraries())) {
+				progress.step(i++, I18n.translateFormatted("progress.jar.custom_indexing.indexer", service.getId()));
+				service.acceptJar(classProvider, index);
+			}
 		}
 
 		progress.step(i, I18n.translate("progress.jar.custom_indexing.finished"));

--- a/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
@@ -123,20 +123,22 @@ public class Enigma {
 	}
 
 	private void index(JarIndex index, ProjectClassProvider classProvider, ProgressListener progress) {
+		boolean libraries = index instanceof LibrariesJarIndex;
+		String progressKey = libraries ? "libs" : "jar";
 		index.indexJar(classProvider, progress);
 
 		List<JarIndexerService> indexers = this.services.get(JarIndexerService.TYPE);
-		progress.init(indexers.size(), I18n.translate("progress.jar.custom_indexing"));
+		progress.init(indexers.size(), I18n.translate("progress." + progressKey + ".custom_indexing"));
 
 		int i = 1;
 		for (var service : indexers) {
-			if (!(index instanceof LibrariesJarIndex && !service.shouldIndexLibraries())) {
-				progress.step(i++, I18n.translateFormatted("progress.jar.custom_indexing.indexer", service.getId()));
-				service.acceptJar(classProvider, index);
+			if (!(libraries && !service.shouldIndexLibraries())) {
+				progress.step(i++, I18n.translateFormatted("progress." + progressKey + ".custom_indexing.indexer", service.getId()));
+				service.acceptJar(libraries ? classProvider.getLibraryClassNames() : classProvider.getMainClassNames(), classProvider, index);
 			}
 		}
 
-		progress.step(i, I18n.translate("progress.jar.custom_indexing.finished"));
+		progress.step(i, I18n.translate("progress." + progressKey + ".custom_indexing.finished"));
 	}
 
 	public EnigmaProfile getProfile() {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
@@ -5,6 +5,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.LibrariesJarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.analysis.index.mapping.MappingsIndex;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.impl.analysis.ClassLoaderClassProvider;
 import org.quiltmc.enigma.api.service.EnigmaService;
 import org.quiltmc.enigma.api.service.EnigmaServiceContext;
@@ -43,13 +44,11 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class Enigma {
@@ -85,14 +84,10 @@ public class Enigma {
 		ClassLoaderClassProvider jreProvider = new ClassLoaderClassProvider(DriverManager.class.getClassLoader());
 		CombiningClassProvider librariesProvider = new CombiningClassProvider(jreProvider, libraryClassProvider);
 		ClassProvider mainProjectProvider = new ObfuscationFixClassProvider(new CachingClassProvider(jarClassProvider), index);
-
-		Set<String> mainScope = new HashSet<>(mainProjectProvider.getClassNames());
-		Set<String> librariesScope = new HashSet<>(librariesProvider.getClassNames());
+		ProjectClassProvider projectClassProvider = new ProjectClassProvider(mainProjectProvider, librariesProvider);
 
 		// main index
-		this.index(index, mainProjectProvider, mainScope, progress, false);
-		// lib index
-		this.index(libIndex, librariesProvider, librariesScope, progress, true);
+		this.index(index, projectClassProvider, progress);
 
 		// name proposal
 		var nameProposalServices = this.getNameProposalServices();
@@ -124,22 +119,19 @@ public class Enigma {
 		return new EnigmaProject(this, path, mainProjectProvider, index, libIndex, mappingsIndex, proposedNames, Utils.zipSha1(path));
 	}
 
-	private void index(JarIndex index, ClassProvider classProvider, Set<String> scope, ProgressListener progress, boolean libraries) {
-		String progressKey = libraries ? "libs" : "jar";
-		index.indexJar(scope, classProvider, progress);
+	private void index(JarIndex index, ProjectClassProvider classProvider, ProgressListener progress) {
+		index.indexJar(classProvider, progress);
 
 		List<JarIndexerService> indexers = this.services.get(JarIndexerService.TYPE);
-		progress.init(indexers.size(), I18n.translate("progress." + progressKey + ".custom_indexing"));
+		progress.init(indexers.size(), I18n.translate("progress.jar.custom_indexing"));
 
 		int i = 1;
 		for (var service : indexers) {
-			if (!(libraries && !service.shouldIndexLibraries())) {
-				progress.step(i++, I18n.translateFormatted("progress." + progressKey + ".custom_indexing.indexer", service.getId()));
-				service.acceptJar(scope, classProvider, index);
-			}
+			progress.step(i++, I18n.translateFormatted("progress.jar.custom_indexing.indexer", service.getId()));
+			service.acceptJar(classProvider, index);
 		}
 
-		progress.step(i, I18n.translate("progress." + progressKey + ".custom_indexing.finished"));
+		progress.step(i, I18n.translate("progress.jar.custom_indexing.finished"));
 	}
 
 	public EnigmaProfile getProfile() {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/JarIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/JarIndex.java
@@ -2,12 +2,10 @@ package org.quiltmc.enigma.api.analysis.index.jar;
 
 import com.google.common.collect.ListMultimap;
 import org.quiltmc.enigma.api.ProgressListener;
-import org.quiltmc.enigma.api.class_provider.ClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.translation.mapping.EntryResolver;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.ParentedEntry;
-
-import java.util.Set;
 
 public interface JarIndex extends JarIndexer {
 	/**
@@ -19,11 +17,10 @@ public interface JarIndex extends JarIndexer {
 
 	/**
 	 * Runs every configured indexer over the provided jar.
-	 * @param classNames the obfuscated names of each class in the jar
-	 * @param classProvider a class provider containing all classes in the jar
+	 * @param classProvider a class provider containing all classes in the jar and libraries
 	 * @param progress a progress listener to track index completion
 	 */
-	void indexJar(Set<String> classNames, ClassProvider classProvider, ProgressListener progress);
+	void indexJar(ProjectClassProvider classProvider, ProgressListener progress);
 
 	/**
 	 * {@return an entry resolver with this index's contents as context}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/LibrariesJarIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/LibrariesJarIndex.java
@@ -1,5 +1,7 @@
 package org.quiltmc.enigma.api.analysis.index.jar;
 
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.impl.analysis.index.AbstractJarIndex;
 
 public class LibrariesJarIndex extends AbstractJarIndex {
@@ -21,5 +23,10 @@ public class LibrariesJarIndex extends AbstractJarIndex {
 	@Override
 	public String getTranslationKey() {
 		return "progress.jar.indexing.libraries";
+	}
+
+	@Override
+	public void indexJar(ProjectClassProvider classProvider, ProgressListener progress) {
+		this.indexJar(classProvider.getLibraryClassNames(), classProvider, progress);
 	}
 }

--- a/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/MainJarIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/analysis/index/jar/MainJarIndex.java
@@ -1,5 +1,7 @@
 package org.quiltmc.enigma.api.analysis.index.jar;
 
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.impl.analysis.index.AbstractJarIndex;
 
 public class MainJarIndex extends AbstractJarIndex {
@@ -25,5 +27,10 @@ public class MainJarIndex extends AbstractJarIndex {
 	@Override
 	public String getTranslationKey() {
 		return "progress.jar.indexing.jar";
+	}
+
+	@Override
+	public void indexJar(ProjectClassProvider classProvider, ProgressListener progress) {
+		this.indexJar(classProvider.getMainClassNames(), classProvider, progress);
 	}
 }

--- a/enigma/src/main/java/org/quiltmc/enigma/api/class_provider/ObfuscationFixClassProvider.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/class_provider/ObfuscationFixClassProvider.java
@@ -45,7 +45,7 @@ public class ObfuscationFixClassProvider implements ClassProvider {
 	public ClassNode get(String name) {
 		ClassNode node = this.classProvider.get(name);
 
-		if (!this.jarIndex.isIndexed(name)) {
+		if (!this.jarIndex.isIndexed(name) || node == null) {
 			return node;
 		}
 

--- a/enigma/src/main/java/org/quiltmc/enigma/api/class_provider/ProjectClassProvider.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/class_provider/ProjectClassProvider.java
@@ -1,0 +1,88 @@
+package org.quiltmc.enigma.api.class_provider;
+
+import org.objectweb.asm.tree.ClassNode;
+
+import javax.annotation.Nullable;
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+
+public class ProjectClassProvider implements ClassProvider {
+	@Nullable
+	private final ClassProvider main;
+	@Nullable
+	private final ClassProvider libraries;
+	private final Collection<String> classNames;
+
+	public ProjectClassProvider(@Nullable ClassProvider main, @Nullable ClassProvider libraries) {
+		if (main == null && libraries == null) {
+			throw new InvalidParameterException("cannot create a project class provider with both main and library providers as null!");
+		}
+
+		this.main = main;
+		this.libraries = libraries;
+		this.classNames = new ArrayList<>();
+		if (main != null) {
+			this.classNames.addAll(main.getClassNames());
+		}
+
+		if (libraries != null) {
+			this.classNames.addAll(libraries.getClassNames());
+		}
+	}
+
+	@Nullable
+	@Override
+	public ClassNode get(String name) {
+		// i hate working with nullability and am a bad programmer. btw
+		ClassNode mainNode;
+		if (this.main != null) {
+			mainNode = this.main.get(name);
+			if (mainNode != null) {
+				return mainNode;
+			}
+		}
+
+		if (this.libraries != null) {
+			return this.libraries.get(name);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets the {@linkplain ClassNode} for a class in the main JAR file. The class provider may return a cached result,
+	 * so it's important to not mutate it.
+	 *
+	 * @param name the internal name of the class
+	 * @return the {@linkplain ClassNode} for that class, or {@code null} if it was not found
+	 */
+	public ClassNode getMainClass(String name) {
+		return this.main != null ? this.main.get(name) : null;
+	}
+
+	/**
+	 * Gets the {@linkplain ClassNode} for a class in the provided libraries. The class provider may return a cached result,
+	 * so it's important to not mutate it.
+	 *
+	 * @param name the internal name of the class
+	 * @return the {@linkplain ClassNode} for that class, or {@code null} if it was not found
+	 */
+	public ClassNode getLibraryClass(String name) {
+		return this.libraries != null ? this.libraries.get(name) : null;
+	}
+
+	@Override
+	public Collection<String> getClassNames() {
+		return this.classNames;
+	}
+
+	public Collection<String> getMainClassNames() {
+		return this.main != null ? this.main.getClassNames() : new HashSet<>();
+	}
+
+	public Collection<String> getLibraryClassNames() {
+		return this.libraries != null ? this.libraries.getClassNames() : new HashSet<>();
+	}
+}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/class_provider/ProjectClassProvider.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/class_provider/ProjectClassProvider.java
@@ -6,7 +6,7 @@ import javax.annotation.Nullable;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 
 public class ProjectClassProvider implements ClassProvider {
 	@Nullable
@@ -58,7 +58,7 @@ public class ProjectClassProvider implements ClassProvider {
 	 * @param name the internal name of the class
 	 * @return the {@linkplain ClassNode} for that class, or {@code null} if it was not found
 	 */
-	public ClassNode getMainClass(String name) {
+	public @Nullable ClassNode getMainClass(String name) {
 		return this.main != null ? this.main.get(name) : null;
 	}
 
@@ -69,7 +69,7 @@ public class ProjectClassProvider implements ClassProvider {
 	 * @param name the internal name of the class
 	 * @return the {@linkplain ClassNode} for that class, or {@code null} if it was not found
 	 */
-	public ClassNode getLibraryClass(String name) {
+	public @Nullable ClassNode getLibraryClass(String name) {
 		return this.libraries != null ? this.libraries.get(name) : null;
 	}
 
@@ -79,10 +79,10 @@ public class ProjectClassProvider implements ClassProvider {
 	}
 
 	public Collection<String> getMainClassNames() {
-		return this.main != null ? this.main.getClassNames() : new HashSet<>();
+		return this.main != null ? this.main.getClassNames() : Collections.emptySet();
 	}
 
 	public Collection<String> getLibraryClassNames() {
-		return this.libraries != null ? this.libraries.getClassNames() : new HashSet<>();
+		return this.libraries != null ? this.libraries.getClassNames() : Collections.emptySet();
 	}
 }

--- a/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
@@ -3,7 +3,11 @@ package org.quiltmc.enigma.api.service;
 import org.objectweb.asm.tree.ClassNode;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.objectweb.asm.ClassVisitor;
+import org.quiltmc.enigma.api.analysis.index.jar.LibrariesJarIndex;
 import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
 
 /**
  * Jar indexer services analyse jar files as they're opened to collect information about their contents.
@@ -14,11 +18,33 @@ public interface JarIndexerService extends EnigmaService {
 	EnigmaServiceType<JarIndexerService> TYPE = EnigmaServiceType.create("jar_indexer");
 
 	/**
+	 * Checks the {@code index_libraries} argument in the context to determine if libraries should be indexed.
+	 * @param context the context for this service
+	 * @return whether libraries should be indexed
+	 */
+	static boolean shouldIndexLibraries(@Nullable EnigmaServiceContext<JarIndexerService> context) {
+		if (context == null) {
+			return false;
+		}
+
+		return context.getSingleArgument("index_libraries").map(Boolean::parseBoolean).orElse(false);
+	}
+
+	/**
 	 * Indexes a collection of classes.
-	 * @param classProvider a provider to translate class names into {@link ClassNode class nodes}.
+	 * @param classProvider a provider to translate class names into {@link ClassNode class nodes}. Contains both library and main JAR classes
 	 * @param jarIndex the current jar index
 	 */
 	void acceptJar(ProjectClassProvider classProvider, JarIndex jarIndex);
+
+	/**
+	 * Whether this indexer should be run on libraries in addition to the main project being indexed.
+	 * @implNote implementations should use {@link #shouldIndexLibraries(EnigmaServiceContext)} to allow changing this setting via the {@link org.quiltmc.enigma.api.EnigmaProfile profile}
+	 * @return whether this indexer should target libraries
+	 */
+	default boolean shouldIndexLibraries() {
+		return false;
+	}
 
 	/**
 	 * Creates an indexer service that runs all {@link ClassNode class nodes} through the provided {@link ClassVisitor visitor}.
@@ -27,10 +53,26 @@ public interface JarIndexerService extends EnigmaService {
 	 * @return the indexer service
 	 */
 	static JarIndexerService fromVisitor(ClassVisitor visitor, String id) {
+		return fromVisitor(null, visitor, id);
+	}
+
+	/**
+	 * Creates an indexer service that runs all {@link ClassNode class nodes} through the provided {@link ClassVisitor visitor}.
+	 * Overrides {@link #shouldIndexLibraries()} according to the profile argument described in {@link #shouldIndexLibraries(EnigmaServiceContext)}.
+	 * @param context the profile context for the service
+	 * @param visitor the visitor to pass classes through
+	 * @param id the service's ID
+	 * @return the indexer service
+	 */
+	static JarIndexerService fromVisitor(@Nullable EnigmaServiceContext<JarIndexerService> context, ClassVisitor visitor, String id) {
+		boolean indexLibs = shouldIndexLibraries(context);
+
 		return new JarIndexerService() {
 			@Override
 			public void acceptJar(ProjectClassProvider classProvider, JarIndex jarIndex) {
-				for (String className : classProvider.getClassNames()) {
+				Collection<String> names = jarIndex instanceof LibrariesJarIndex ? classProvider.getLibraryClassNames() : classProvider.getMainClassNames();
+
+				for (String className : names) {
 					ClassNode node = classProvider.get(className);
 					if (node != null) {
 						node.accept(visitor);
@@ -41,6 +83,11 @@ public interface JarIndexerService extends EnigmaService {
 			@Override
 			public String getId() {
 				return id;
+			}
+
+			@Override
+			public boolean shouldIndexLibraries() {
+				return indexLibs;
 			}
 		};
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
@@ -31,8 +31,8 @@ public interface JarIndexerService extends EnigmaService {
 
 	/**
 	 * Indexes a collection of classes.
-	 * @param scope the current scope to be indexed. This is either all main JAR classes or all library classes
-	 * @param classProvider a provider to translate class names into {@link ClassNode class nodes}. Contains both library and main JAR classes
+	 * @param scope the current scope to be indexed. This is either all main jar classes or all library classes
+	 * @param classProvider a provider to translate class names into {@link ClassNode class nodes}. Contains both library and main jar classes
 	 * @param jarIndex the current jar index
 	 */
 	void acceptJar(Collection<String> scope, ProjectClassProvider classProvider, JarIndex jarIndex);

--- a/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
@@ -2,11 +2,8 @@ package org.quiltmc.enigma.api.service;
 
 import org.objectweb.asm.tree.ClassNode;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
-import org.quiltmc.enigma.api.class_provider.ClassProvider;
 import org.objectweb.asm.ClassVisitor;
-
-import javax.annotation.Nullable;
-import java.util.Set;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 
 /**
  * Jar indexer services analyse jar files as they're opened to collect information about their contents.
@@ -17,34 +14,11 @@ public interface JarIndexerService extends EnigmaService {
 	EnigmaServiceType<JarIndexerService> TYPE = EnigmaServiceType.create("jar_indexer");
 
 	/**
-	 * Checks the {@code index_libraries} argument in the context to determine if libraries should be indexed.
-	 * @param context the context for this service
-	 * @return whether libraries should be indexed
-	 */
-	static boolean shouldIndexLibraries(@Nullable EnigmaServiceContext<JarIndexerService> context) {
-		if (context == null) {
-			return false;
-		}
-
-		return context.getSingleArgument("index_libraries").map(Boolean::parseBoolean).orElse(false);
-	}
-
-	/**
 	 * Indexes a collection of classes.
-	 * @param scope a list of class names to be indexed
-	 * @param classProvider a provider to translate class names into {@link ClassNode class nodes}
+	 * @param classProvider a provider to translate class names into {@link ClassNode class nodes}.
 	 * @param jarIndex the current jar index
 	 */
-	void acceptJar(Set<String> scope, ClassProvider classProvider, JarIndex jarIndex);
-
-	/**
-	 * Whether this indexer should be run on libraries in addition to the main project being indexed.
-	 * @implNote implementations should use {@link #shouldIndexLibraries(EnigmaServiceContext)} to allow changing this setting via the {@link org.quiltmc.enigma.api.EnigmaProfile profile}
-	 * @return whether this indexer should target libraries
-	 */
-	default boolean shouldIndexLibraries() {
-		return false;
-	}
+	void acceptJar(ProjectClassProvider classProvider, JarIndex jarIndex);
 
 	/**
 	 * Creates an indexer service that runs all {@link ClassNode class nodes} through the provided {@link ClassVisitor visitor}.
@@ -53,24 +27,10 @@ public interface JarIndexerService extends EnigmaService {
 	 * @return the indexer service
 	 */
 	static JarIndexerService fromVisitor(ClassVisitor visitor, String id) {
-		return fromVisitor(null, visitor, id);
-	}
-
-	/**
-	 * Creates an indexer service that runs all {@link ClassNode class nodes} through the provided {@link ClassVisitor visitor}.
-	 * Overrides {@link #shouldIndexLibraries()} according to the profile argument described in {@link #shouldIndexLibraries(EnigmaServiceContext)}.
-	 * @param context the profile context for the service
-	 * @param visitor the visitor to pass classes through
-	 * @param id the service's ID
-	 * @return the indexer service
-	 */
-	static JarIndexerService fromVisitor(@Nullable EnigmaServiceContext<JarIndexerService> context, ClassVisitor visitor, String id) {
-		boolean indexLibs = shouldIndexLibraries(context);
-
 		return new JarIndexerService() {
 			@Override
-			public void acceptJar(Set<String> scope, ClassProvider classProvider, JarIndex jarIndex) {
-				for (String className : scope) {
+			public void acceptJar(ProjectClassProvider classProvider, JarIndex jarIndex) {
+				for (String className : classProvider.getClassNames()) {
 					ClassNode node = classProvider.get(className);
 					if (node != null) {
 						node.accept(visitor);
@@ -81,11 +41,6 @@ public interface JarIndexerService extends EnigmaService {
 			@Override
 			public String getId() {
 				return id;
-			}
-
-			@Override
-			public boolean shouldIndexLibraries() {
-				return indexLibs;
 			}
 		};
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/service/JarIndexerService.java
@@ -3,7 +3,6 @@ package org.quiltmc.enigma.api.service;
 import org.objectweb.asm.tree.ClassNode;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.objectweb.asm.ClassVisitor;
-import org.quiltmc.enigma.api.analysis.index.jar.LibrariesJarIndex;
 import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 
 import javax.annotation.Nullable;
@@ -32,10 +31,11 @@ public interface JarIndexerService extends EnigmaService {
 
 	/**
 	 * Indexes a collection of classes.
+	 * @param scope the current scope to be indexed. This is either all main JAR classes or all library classes
 	 * @param classProvider a provider to translate class names into {@link ClassNode class nodes}. Contains both library and main JAR classes
 	 * @param jarIndex the current jar index
 	 */
-	void acceptJar(ProjectClassProvider classProvider, JarIndex jarIndex);
+	void acceptJar(Collection<String> scope, ProjectClassProvider classProvider, JarIndex jarIndex);
 
 	/**
 	 * Whether this indexer should be run on libraries in addition to the main project being indexed.
@@ -69,10 +69,8 @@ public interface JarIndexerService extends EnigmaService {
 
 		return new JarIndexerService() {
 			@Override
-			public void acceptJar(ProjectClassProvider classProvider, JarIndex jarIndex) {
-				Collection<String> names = jarIndex instanceof LibrariesJarIndex ? classProvider.getLibraryClassNames() : classProvider.getMainClassNames();
-
-				for (String className : names) {
+			public void acceptJar(Collection<String> scope, ProjectClassProvider classProvider, JarIndex jarIndex) {
+				for (String className : scope) {
 					ClassNode node = classProvider.get(className);
 					if (node != null) {
 						node.accept(visitor);

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/analysis/index/AbstractJarIndex.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/analysis/index/AbstractJarIndex.java
@@ -25,6 +25,7 @@ import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.ParentedEntry;
 import org.quiltmc.enigma.util.I18n;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -72,11 +73,10 @@ public abstract class AbstractJarIndex implements JarIndex {
 
 	/**
 	 * Runs every configured indexer over the provided jar.
-	 * @param classNames the obfuscated names of each class in the jar
 	 * @param classProvider a class provider containing all classes in the jar
 	 * @param progress a progress listener to track index completion
 	 */
-	public void indexJar(Set<String> classNames, ClassProvider classProvider, ProgressListener progress) {
+	public void indexJar(Collection<String> classNames, ClassProvider classProvider, ProgressListener progress) {
 		// for use in processIndex
 		this.progress = progress;
 

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/plugin/BuiltinPlugin.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/plugin/BuiltinPlugin.java
@@ -34,7 +34,7 @@ public final class BuiltinPlugin implements EnigmaPlugin {
 		final Map<Entry<?>, String> names = new HashMap<>();
 		final EnumFieldNameFindingVisitor visitor = new EnumFieldNameFindingVisitor(names);
 
-		ctx.registerService(JarIndexerService.TYPE, ctx1 -> JarIndexerService.fromVisitor(ctx1, visitor, "enigma:enum_initializer_indexer"));
+		ctx.registerService(JarIndexerService.TYPE, ctx1 -> JarIndexerService.fromVisitor(visitor, "enigma:enum_initializer_indexer"));
 
 		ctx.registerService(NameProposalService.TYPE, ctx1 -> new NameProposalService() {
 			@Override
@@ -66,7 +66,7 @@ public final class BuiltinPlugin implements EnigmaPlugin {
 		final Map<FieldEntry, MethodEntry> fieldToGetter = new HashMap<>();
 		final RecordGetterFindingVisitor visitor = new RecordGetterFindingVisitor(fieldToGetter);
 
-		ctx.registerService(JarIndexerService.TYPE, ctx1 -> JarIndexerService.fromVisitor(ctx1, visitor, "enigma:record_component_indexer"));
+		ctx.registerService(JarIndexerService.TYPE, ctx1 -> JarIndexerService.fromVisitor(visitor, "enigma:record_component_indexer"));
 		ctx.registerService(NameProposalService.TYPE, ctx1 -> new RecordComponentProposalService(fieldToGetter));
 	}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/PackageVisibilityIndexTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/PackageVisibilityIndexTest.java
@@ -4,7 +4,9 @@ import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.PackageVisibilityIndex;
 import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.class_provider.CachingClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +29,7 @@ public class PackageVisibilityIndexTest {
 	public PackageVisibilityIndexTest() throws Exception {
 		JarClassProvider jcp = new JarClassProvider(JAR);
 		this.jarIndex = MainJarIndex.empty();
-		this.jarIndex.indexJar(jcp.getClassNames(), jcp, ProgressListener.createEmpty());
+		this.jarIndex.indexJar(new ProjectClassProvider(new CachingClassProvider(jcp), null), ProgressListener.createEmpty());
 	}
 
 	@Test

--- a/enigma/src/test/java/org/quiltmc/enigma/TestInnerClasses.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TestInnerClasses.java
@@ -6,6 +6,7 @@ import org.quiltmc.enigma.api.ProgressListener;
 import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.class_provider.CachingClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.source.Decompiler;
 import org.quiltmc.enigma.api.source.Decompilers;
 import org.quiltmc.enigma.api.source.SourceSettings;
@@ -34,7 +35,7 @@ public class TestInnerClasses {
 		JarClassProvider jcp = new JarClassProvider(JAR);
 		CachingClassProvider classProvider = new CachingClassProvider(jcp);
 		this.index = MainJarIndex.empty();
-		this.index.indexJar(jcp.getClassNames(), classProvider, ProgressListener.createEmpty());
+		this.index.indexJar(new ProjectClassProvider(classProvider, null), ProgressListener.createEmpty());
 		this.decompiler = Decompilers.CFR.create(classProvider, new SourceSettings(false, false));
 	}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexBridgeMethods.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexBridgeMethods.java
@@ -8,6 +8,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.class_provider.CachingClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
 import org.quiltmc.enigma.api.class_provider.ObfuscationFixClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.service.DecompilerService;
 import org.quiltmc.enigma.api.source.Decompilers;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
@@ -40,7 +41,7 @@ public class TestJarIndexBridgeMethods {
 		JarClassProvider jcp = new JarClassProvider(JAR);
 		this.classProvider = new CachingClassProvider(jcp);
 		this.index = MainJarIndex.empty();
-		this.index.indexJar(jcp.getClassNames(), this.classProvider, ProgressListener.createEmpty());
+		this.index.indexJar(new ProjectClassProvider(this.classProvider, null), ProgressListener.createEmpty());
 	}
 
 	@Test

--- a/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexConstructorReferences.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexConstructorReferences.java
@@ -8,6 +8,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.ReferenceIndex;
 import org.quiltmc.enigma.api.class_provider.CachingClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodDefEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
@@ -34,7 +35,7 @@ public class TestJarIndexConstructorReferences {
 	public TestJarIndexConstructorReferences() throws Exception {
 		JarClassProvider jcp = new JarClassProvider(JAR);
 		this.index = MainJarIndex.empty();
-		this.index.indexJar(jcp.getClassNames(), new CachingClassProvider(jcp), ProgressListener.createEmpty());
+		this.index.indexJar(new ProjectClassProvider(new CachingClassProvider(jcp), null), ProgressListener.createEmpty());
 	}
 
 	@Test

--- a/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexInheritanceTree.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexInheritanceTree.java
@@ -9,6 +9,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.ReferenceIndex;
 import org.quiltmc.enigma.api.class_provider.CachingClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.translation.mapping.EntryResolver;
 import org.quiltmc.enigma.api.translation.mapping.IndexEntryResolver;
 import org.quiltmc.enigma.api.translation.representation.AccessFlags;
@@ -41,7 +42,7 @@ public class TestJarIndexInheritanceTree {
 	public TestJarIndexInheritanceTree() throws Exception {
 		JarClassProvider jcp = new JarClassProvider(JAR);
 		this.index = MainJarIndex.empty();
-		this.index.indexJar(jcp.getClassNames(), new CachingClassProvider(jcp), ProgressListener.createEmpty());
+		this.index.indexJar(new ProjectClassProvider(new CachingClassProvider(jcp), null), ProgressListener.createEmpty());
 	}
 
 	@Test

--- a/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexLoneClass.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TestJarIndexLoneClass.java
@@ -6,6 +6,7 @@ import org.quiltmc.enigma.api.analysis.tree.ClassImplementationsTreeNode;
 import org.quiltmc.enigma.api.analysis.tree.ClassInheritanceTreeNode;
 import org.quiltmc.enigma.api.ProgressListener;
 import org.quiltmc.enigma.api.analysis.EntryReference;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.impl.analysis.IndexTreeBuilder;
 import org.quiltmc.enigma.api.analysis.tree.MethodImplementationsTreeNode;
 import org.quiltmc.enigma.api.analysis.tree.MethodInheritanceTreeNode;
@@ -37,7 +38,7 @@ public class TestJarIndexLoneClass {
 	public TestJarIndexLoneClass() throws Exception {
 		JarClassProvider jcp = new JarClassProvider(JAR);
 		this.index = MainJarIndex.empty();
-		this.index.indexJar(jcp.getClassNames(), new CachingClassProvider(jcp), ProgressListener.createEmpty());
+		this.index.indexJar(new ProjectClassProvider(new CachingClassProvider(jcp), null), ProgressListener.createEmpty());
 	}
 
 	@Test

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/IndexEntryResolverTest.java
@@ -11,6 +11,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.EntryIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.MainJarIndex;
 import org.quiltmc.enigma.api.class_provider.ClassProvider;
+import org.quiltmc.enigma.api.class_provider.ProjectClassProvider;
 import org.quiltmc.enigma.api.translation.mapping.IndexEntryResolver;
 import org.quiltmc.enigma.api.translation.mapping.ResolutionStrategy;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
@@ -22,7 +23,6 @@ import org.quiltmc.enigma.test.bytecode.MethodNodeBuilder;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public class IndexEntryResolverTest {
 	@BeforeAll
 	public static void beforeAll() {
 		index = MainJarIndex.empty();
-		index.indexJar(new HashSet<>(CLASS_PROVIDER.getClassNames()), CLASS_PROVIDER, ProgressListener.createEmpty());
+		index.indexJar(new ProjectClassProvider(CLASS_PROVIDER, null), ProgressListener.createEmpty());
 		resolver = new IndexEntryResolver(index);
 	}
 


### PR DESCRIPTION
- provide full context of all known classes for indexers, both plugin and non-plugin
- remove redundant scope param for non-plugin indexers
- fixes issues with the plugin blocking 2.5