### PR TITLE
fix a bunch of parameter javadoc issues

### DIFF
--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/serde/tinyv2/TinyV2Writer.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/serde/tinyv2/TinyV2Writer.java
@@ -209,13 +209,13 @@ public final class TinyV2Writer implements MappingsWriter {
 		writer.print(node.getEntry().getName());
 		writer.print("\t");
 		EntryMapping mapping = node.getValue();
-		if (mapping == null || mapping.targetName() == null) {
-			writer.println(); // todo ???
-		} else {
+		if (mapping.targetName() == null) {
 			writer.println(mapping.targetName());
-
-			this.writeComment(writer, mapping, 3);
+		} else {
+			writer.println();
 		}
+
+		this.writeComment(writer, mapping, 3);
 	}
 
 	private void writeComment(PrintWriter writer, EntryMapping mapping, int indent) {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/serde/tinyv2/TinyV2Writer.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/serde/tinyv2/TinyV2Writer.java
@@ -209,7 +209,7 @@ public final class TinyV2Writer implements MappingsWriter {
 		writer.print(node.getEntry().getName());
 		writer.print("\t");
 		EntryMapping mapping = node.getValue();
-		if (mapping.targetName() == null) {
+		if (mapping.targetName() != null) {
 			writer.println(mapping.targetName());
 		} else {
 			writer.println();

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/vineflower/EnigmaJavadocProvider.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/vineflower/EnigmaJavadocProvider.java
@@ -2,6 +2,7 @@ package org.quiltmc.enigma.impl.source.vineflower;
 
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
+import org.quiltmc.enigma.api.translation.mapping.ResolutionStrategy;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 import org.quiltmc.enigma.api.translation.representation.entry.FieldEntry;
@@ -102,7 +103,15 @@ public class EnigmaJavadocProvider implements IFabricJavadocProvider {
 						EntryMapping paramMapping = this.remapper.getMapping(child);
 
 						if (paramMapping.javadoc() != null) {
-							builder.append("\n@param ").append(paramMapping.targetName()).append(' ').append(paramMapping.javadoc());
+							// for overridden methods, it's possible that we have no name and need to search for the root
+							String name = paramMapping.targetName();
+							if (name == null) {
+								var root = this.remapper.getObfResolver().resolveFirstEntry(child, ResolutionStrategy.RESOLVE_ROOT);
+								EntryMapping rootMapping = this.remapper.getMapping(root); // root entry will never be null
+								name = rootMapping.targetName();
+							}
+
+							builder.append("\n@param ").append(name).append(' ').append(paramMapping.javadoc());
 						}
 					}
 				}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interfaces/Inheritor.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interfaces/Inheritor.java
@@ -1,0 +1,13 @@
+package org.quiltmc.enigma.input.interfaces;
+
+public class Inheritor implements Root {
+	@Override
+	public int a() {
+		return 23;
+	}
+
+	@Override
+	public double b(double c) {
+		return c + 100d;
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interfaces/Root.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interfaces/Root.java
@@ -1,0 +1,7 @@
+package org.quiltmc.enigma.input.interfaces;
+
+public interface Root {
+	public int a();
+
+	public double b(double c);
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/interfaces/Root.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/interfaces/Root.java
@@ -1,7 +1,7 @@
 package org.quiltmc.enigma.input.interfaces;
 
 public interface Root {
-	public int a();
+	int a();
 
-	public double b(double c);
+	double b(double c);
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMethodOverrideParamJavadoc.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/translation/mapping/TestMethodOverrideParamJavadoc.java
@@ -1,0 +1,83 @@
+package org.quiltmc.enigma.translation.mapping;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.enigma.TestEntryFactory;
+import org.quiltmc.enigma.TestUtil;
+import org.quiltmc.enigma.api.Enigma;
+import org.quiltmc.enigma.api.EnigmaProject;
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
+import org.quiltmc.enigma.api.service.ReadWriteService;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.serde.FileType;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingFileNameFormat;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingParseException;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
+import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
+import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+public class TestMethodOverrideParamJavadoc {
+	private static final MappingSaveParameters PARAMETERS = new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF, false, null, null);
+	private static final Path JAR = TestUtil.obfJar("interfaces");
+	private static Enigma enigma;
+	private static EnigmaProject project;
+
+	@BeforeAll
+	static void setupEnigma() throws IOException {
+		enigma = Enigma.create();
+		project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+	}
+
+	void test(ReadWriteService readWriteService, String tmpNameSuffix) throws IOException, MappingParseException {
+		var remapper = project.getRemapper();
+
+		ClassEntry inheritor = TestEntryFactory.newClass("a");
+		MethodEntry method = TestEntryFactory.newMethod(inheritor, "a", "(D)D");
+		LocalVariableEntry param = TestEntryFactory.newParameter(method, 1);
+
+		EntryMapping mapping = remapper.getMapping(param);
+		Assertions.assertNull(mapping.javadoc());
+
+		remapper.putMapping(TestUtil.newVC(), param, mapping.withJavadoc("gaming"));
+
+		EntryMapping withJavadoc = remapper.getMapping(param);
+		Assertions.assertEquals("gaming", withJavadoc.javadoc());
+
+		File tempFile = File.createTempFile("testMethodOverrideParamJavadoc", tmpNameSuffix);
+		tempFile.delete(); //remove the auto created file
+
+		readWriteService.write(remapper.getMappings(), tempFile.toPath(), ProgressListener.createEmpty(), PARAMETERS);
+		Assertions.assertTrue(tempFile.exists(), "Written file not created");
+		EntryTree<EntryMapping> loadedMappings = readWriteService.read(tempFile.toPath(), ProgressListener.createEmpty());
+
+		project.setMappings(loadedMappings, ProgressListener.createEmpty());
+		remapper = project.getRemapper();
+
+		EntryMapping newMapping = remapper.getMapping(param);
+		Assertions.assertEquals("gaming", newMapping.javadoc());
+	}
+
+	@Test
+	public void testEnigmaFile() throws IOException, MappingParseException {
+		this.test(this.getService(file -> file.getExtensions().contains("mapping") && !file.isDirectory()), ".mapping");
+	}
+
+	@Test
+	public void testTinyFile() throws IOException, MappingParseException {
+		this.test(this.getService(file -> file.getExtensions().contains("tiny") && !file.isDirectory()), ".tiny");
+	}
+
+	@SuppressWarnings("all")
+	private ReadWriteService getService(Predicate<FileType> predicate) {
+		return this.enigma.getReadWriteService(this.enigma.getSupportedFileTypes().stream().filter(predicate).findFirst().get()).get();
+	}
+}


### PR DESCRIPTION
a multipart fix for #225 
- fix tiny remapper not properly writing comments on parameters
- fix override javadoc not properly locating parameter names
- fix javadoc not properly refreshing when parameter names are updated