### PR TITLE
Navigator now correctly handles new mapped items

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/GuiController.java
@@ -548,7 +548,7 @@ public class GuiController implements ClientPacketHandler {
 			boolean renamed = !change.getDeobfName().isUnchanged();
 			this.gui.updateStructure(this.gui.getActiveEditor());
 			if (this.gui.getActiveEditor() != null) {
-				this.gui.getActiveEditor().onRename();
+				this.gui.getActiveEditor().onRename(prev.targetName() == null && mapping.targetName() != null);
 			}
 
 			if (!Objects.equals(prev.targetName(), mapping.targetName()) || !Objects.equals(prev.tokenType(), mapping.tokenType())) {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
@@ -109,6 +109,10 @@ public class NavigatorPanel extends JPanel {
 		}
 	}
 
+	public void decrementIndex() {
+		this.currentIndex--;
+	}
+
 	private void tryNavigate() {
 		this.gui.getController().navigateTo(this.entries.get(this.selectedType).get(this.currentIndex));
 		this.updateStatsLabel();

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
@@ -208,8 +208,9 @@ public class EditorPanel {
 		this.ui.putClientProperty(EditorPanel.class, this);
 	}
 
-	public void onRename() {
+	public void onRename(boolean isNewMapping) {
 		this.navigatorPanel.updateAllTokenTypes();
+		if (isNewMapping) this.navigatorPanel.decrementIndex();
 	}
 
 	@Nullable


### PR DESCRIPTION
The natural way to map out a class would be as follows:
1. Rename mapping
2. Navigate down to the next mapping
3. Repeat
However, previously this would skip mappings as renaming something new would decrease the amount of unmapped items and would thus change which mapping the index was pointing to. This PR changes this behavior so it works correctly,