### PR TITLE
fallback name proposal and name proposal save bypass

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/ThemeUtil.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/ThemeUtil.java
@@ -96,8 +96,7 @@ public final class ThemeUtil {
 	}
 
 	public static BoxHighlightPainter createFallbackPainter() {
-		// todo proper colours
-		return BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().proposed.value(), Config.getCurrentSyntaxPaneColors().debugTokenOutline.value());
+		return BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().fallback.value(), Config.getCurrentSyntaxPaneColors().fallbackOutline.value());
 	}
 
 	public static <T> void resetIfAbsent(TrackedValue<T> value) {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/ThemeUtil.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/ThemeUtil.java
@@ -4,14 +4,12 @@ import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.enigma.gui.config.Config;
 import org.quiltmc.enigma.gui.highlight.BoxHighlightPainter;
 import org.quiltmc.enigma.gui.util.ScaleUtil;
-import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.syntaxpain.JavaSyntaxKit;
 
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.image.BufferedImage;
-import java.util.Map;
 import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.UIManager;

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/ThemeUtil.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/ThemeUtil.java
@@ -79,14 +79,25 @@ public final class ThemeUtil {
 		UIManager.put("Button.font", bold);
 	}
 
-	public static Map<TokenType, BoxHighlightPainter> getBoxHighlightPainters() {
-		return Map.of(
-				TokenType.OBFUSCATED, BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().obfuscated.value(), Config.getCurrentSyntaxPaneColors().obfuscatedOutline.value()),
-				TokenType.JAR_PROPOSED, BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().proposed.value(), Config.getCurrentSyntaxPaneColors().proposedOutline.value()),
-				TokenType.DYNAMIC_PROPOSED, BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().proposed.value(), Config.getCurrentSyntaxPaneColors().proposedOutline.value()),
-				TokenType.DEOBFUSCATED, BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().deobfuscated.value(), Config.getCurrentSyntaxPaneColors().deobfuscatedOutline.value()),
-				TokenType.DEBUG, BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().debugToken.value(), Config.getCurrentSyntaxPaneColors().debugTokenOutline.value())
-		);
+	public static BoxHighlightPainter createObfuscatedPainter() {
+		return BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().obfuscated.value(), Config.getCurrentSyntaxPaneColors().obfuscatedOutline.value());
+	}
+
+	public static BoxHighlightPainter createProposedPainter() {
+		return BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().proposed.value(), Config.getCurrentSyntaxPaneColors().proposedOutline.value());
+	}
+
+	public static BoxHighlightPainter createDeobfuscatedPainter() {
+		return BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().deobfuscated.value(), Config.getCurrentSyntaxPaneColors().deobfuscatedOutline.value());
+	}
+
+	public static BoxHighlightPainter createDebugPainter() {
+		return BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().debugToken.value(), Config.getCurrentSyntaxPaneColors().debugTokenOutline.value());
+	}
+
+	public static BoxHighlightPainter createFallbackPainter() {
+		// todo proper colours
+		return BoxHighlightPainter.create(Config.getCurrentSyntaxPaneColors().proposed.value(), Config.getCurrentSyntaxPaneColors().debugTokenOutline.value());
 	}
 
 	public static <T> void resetIfAbsent(TrackedValue<T> value) {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/DarculaThemeProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/DarculaThemeProperties.java
@@ -54,6 +54,9 @@ public class DarculaThemeProperties extends AbstractDarculaThemeProperties {
 				.deobfuscated(new SerializableColor(0x4D50FA7B))
 				.deobfuscatedOutline(new SerializableColor(0x8050FA7B))
 
+				.fallback(new SerializableColor(0x4Daa5500))
+				.fallbackOutline(new SerializableColor(0x80d86f06))
+
 				.editorBackground(new SerializableColor(0xFF282A36))
 				.highlight(new SerializableColor(0xFFFF79C6))
 				.caret(new SerializableColor(0xFFF8F8F2))

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/composite/SyntaxPaneProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/composite/SyntaxPaneProperties.java
@@ -49,6 +49,9 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 		public final TrackedValue<ThemeProperties.SerializableColor> deobfuscated;
 		public final TrackedValue<ThemeProperties.SerializableColor> deobfuscatedOutline;
 
+		public final TrackedValue<ThemeProperties.SerializableColor> fallback;
+		public final TrackedValue<ThemeProperties.SerializableColor> fallbackOutline;
+
 		public final TrackedValue<ThemeProperties.SerializableColor> editorBackground;
 		public final TrackedValue<ThemeProperties.SerializableColor> highlight;
 		public final TrackedValue<ThemeProperties.SerializableColor> caret;
@@ -78,6 +81,9 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 				ThemeProperties.SerializableColor deobfuscated,
 				ThemeProperties.SerializableColor deobfuscatedOutline,
 
+				ThemeProperties.SerializableColor fallback,
+				ThemeProperties.SerializableColor fallbackOutline,
+
 				ThemeProperties.SerializableColor editorBackground,
 				ThemeProperties.SerializableColor highlight,
 				ThemeProperties.SerializableColor caret,
@@ -105,6 +111,9 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 
 			this.deobfuscated = TrackedValue.create(deobfuscated, "deobfuscated");
 			this.deobfuscatedOutline = TrackedValue.create(deobfuscatedOutline, "deobfuscated_outline");
+
+			this.fallback = TrackedValue.create(fallback, "fallback");
+			this.fallbackOutline = TrackedValue.create(fallback, "fallbackOutline");
 
 			this.editorBackground = TrackedValue.create(editorBackground, "editor_background");
 			this.highlight = TrackedValue.create(highlight, "highlight");
@@ -142,6 +151,9 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 				this.deobfuscated,
 				this.deobfuscatedOutline,
 
+				this.fallback,
+				this.fallbackOutline,
+
 				this.editorBackground,
 				this.highlight,
 				this.caret,
@@ -177,6 +189,11 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 			private ThemeProperties.SerializableColor deobfuscated = new ThemeProperties.SerializableColor(0xFFDCFFDC);
 			private ThemeProperties.SerializableColor deobfuscatedOutline = new ThemeProperties.SerializableColor(0xFF50A050);
 
+			// todo defaults for other themes
+			// todo better colours
+			private ThemeProperties.SerializableColor fallback = new ThemeProperties.SerializableColor(0x60eb8f34);
+			private ThemeProperties.SerializableColor fallbackOutline = new ThemeProperties.SerializableColor(0xFFeb8f34);
+
 			private ThemeProperties.SerializableColor editorBackground = new ThemeProperties.SerializableColor(0xFFFFFFFF);
 			private ThemeProperties.SerializableColor highlight = new ThemeProperties.SerializableColor(0xFF3333EE);
 			private ThemeProperties.SerializableColor caret = new ThemeProperties.SerializableColor(0xFF000000);
@@ -206,6 +223,9 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 
 					this.deobfuscated,
 					this.deobfuscatedOutline,
+
+					this.fallback,
+					this.fallbackOutline,
 
 					this.editorBackground,
 					this.highlight,
@@ -267,6 +287,16 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 
 			public Builder deobfuscatedOutline(ThemeProperties.SerializableColor deobfuscatedOutline) {
 				this.deobfuscatedOutline = deobfuscatedOutline;
+				return this;
+			}
+
+			public Builder fallback(ThemeProperties.SerializableColor fallback) {
+				this.fallback = fallback;
+				return this;
+			}
+
+			public Builder fallbackOutline(ThemeProperties.SerializableColor fallbackOutline) {
+				this.fallbackOutline = fallbackOutline;
 				return this;
 			}
 

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/composite/SyntaxPaneProperties.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/config/theme/properties/composite/SyntaxPaneProperties.java
@@ -113,7 +113,7 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 			this.deobfuscatedOutline = TrackedValue.create(deobfuscatedOutline, "deobfuscated_outline");
 
 			this.fallback = TrackedValue.create(fallback, "fallback");
-			this.fallbackOutline = TrackedValue.create(fallback, "fallbackOutline");
+			this.fallbackOutline = TrackedValue.create(fallbackOutline, "fallbackOutline");
 
 			this.editorBackground = TrackedValue.create(editorBackground, "editor_background");
 			this.highlight = TrackedValue.create(highlight, "highlight");
@@ -189,10 +189,8 @@ public class SyntaxPaneProperties implements Config.Creator, Configurable {
 			private ThemeProperties.SerializableColor deobfuscated = new ThemeProperties.SerializableColor(0xFFDCFFDC);
 			private ThemeProperties.SerializableColor deobfuscatedOutline = new ThemeProperties.SerializableColor(0xFF50A050);
 
-			// todo defaults for other themes
-			// todo better colours
-			private ThemeProperties.SerializableColor fallback = new ThemeProperties.SerializableColor(0x60eb8f34);
-			private ThemeProperties.SerializableColor fallbackOutline = new ThemeProperties.SerializableColor(0xFFeb8f34);
+			private ThemeProperties.SerializableColor fallback = new ThemeProperties.SerializableColor(0xFFffddbb);
+			private ThemeProperties.SerializableColor fallbackOutline = new ThemeProperties.SerializableColor(0xFFd86f06);
 
 			private ThemeProperties.SerializableColor editorBackground = new ThemeProperties.SerializableColor(0xFFFFFFFF);
 			private ThemeProperties.SerializableColor highlight = new ThemeProperties.SerializableColor(0xFF3333EE);

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/ClassSelectorPopupMenu.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/ClassSelectorPopupMenu.java
@@ -1,5 +1,6 @@
 package org.quiltmc.enigma.gui.element;
 
+import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.gui.ClassSelector;
 import org.quiltmc.enigma.gui.Gui;
 import org.quiltmc.enigma.gui.docker.ClassesDocker;
@@ -121,7 +122,7 @@ public class ClassSelectorPopupMenu {
 		// update toggle mapping text to match
 		this.toggleMapping.setEnabled(selected != null);
 		if (selected != null) {
-			if (this.gui.getController().getProject().getRemapper().extendedDeobfuscate(selected).isDeobfuscated()) {
+			if (this.gui.getController().getProject().getRemapper().extendedDeobfuscate(selected).getType() == TokenType.DEOBFUSCATED) {
 				this.toggleMapping.setText(I18n.translate("popup_menu.reset_obfuscated"));
 			} else {
 				this.toggleMapping.setText(I18n.translate("popup_menu.mark_deobfuscated"));

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorPopupMenu.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorPopupMenu.java
@@ -1,6 +1,7 @@
 package org.quiltmc.enigma.gui.element;
 
 import org.quiltmc.enigma.api.analysis.EntryReference;
+import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.gui.EditableType;
 import org.quiltmc.enigma.gui.Gui;
 import org.quiltmc.enigma.gui.GuiController;
@@ -171,7 +172,7 @@ public class EditorPopupMenu {
 		this.openNextItem.setEnabled(controller.hasNextReference());
 		this.toggleMappingItem.setEnabled(isRenamable && (type != null && this.gui.isEditable(type)));
 
-		if (referenceEntry != null && this.gui.getController().getProject().getRemapper().extendedDeobfuscate(referenceEntry).isDeobfuscated()) {
+		if (referenceEntry != null && this.gui.getController().getProject().getRemapper().extendedDeobfuscate(referenceEntry).getType() == TokenType.DEOBFUSCATED) {
 			this.toggleMappingItem.setText(I18n.translate("popup_menu.reset_obfuscated"));
 		} else {
 			this.toggleMappingItem.setText(I18n.translate("popup_menu.mark_deobfuscated"));

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
@@ -5,6 +5,7 @@ import org.quiltmc.enigma.api.analysis.EntryReference;
 import org.quiltmc.enigma.api.class_handle.ClassHandle;
 import org.quiltmc.enigma.api.class_handle.ClassHandleError;
 import org.quiltmc.enigma.api.event.ClassHandleListener;
+import org.quiltmc.enigma.api.source.TokenStore;
 import org.quiltmc.enigma.gui.BrowserCaret;
 import org.quiltmc.enigma.gui.EditableType;
 import org.quiltmc.enigma.gui.Gui;
@@ -96,7 +97,11 @@ public class EditorPanel {
 	private boolean shouldNavigateOnClick;
 
 	private int fontSize = 12;
-	private final Map<TokenType, BoxHighlightPainter> boxHighlightPainters;
+	private final BoxHighlightPainter obfuscatedPainter;
+	private final BoxHighlightPainter proposedPainter;
+	private final BoxHighlightPainter deobfuscatedPainter;
+	private final BoxHighlightPainter debugPainter;
+	public final BoxHighlightPainter fallbackPainter;
 
 	private final List<EditorActionListener> listeners = new ArrayList<>();
 
@@ -132,7 +137,11 @@ public class EditorPanel {
 		this.errorTextArea.setEditable(false);
 		this.errorTextArea.setFont(ScaleUtil.getFont(Font.MONOSPACED, Font.PLAIN, 10));
 
-		this.boxHighlightPainters = ThemeUtil.getBoxHighlightPainters();
+		this.obfuscatedPainter = ThemeUtil.createObfuscatedPainter();
+		this.proposedPainter = ThemeUtil.createProposedPainter();
+		this.debugPainter = ThemeUtil.createDebugPainter();
+		this.fallbackPainter = ThemeUtil.createFallbackPainter();
+		this.deobfuscatedPainter = ThemeUtil.createDeobfuscatedPainter();
 
 		this.editor.addMouseListener(new MouseAdapter() {
 			@Override
@@ -464,7 +473,7 @@ public class EditorPanel {
 			this.editor.getHighlighter().removeAllHighlights();
 			this.editor.setText(source.toString());
 
-			this.setHighlightedTokens(source.getHighlightedTokens());
+			this.setHighlightedTokens(source.getTokenStore(), source.getHighlightedTokens());
 			if (this.source != null) {
 				this.editor.setCaretPosition(newCaretPos);
 
@@ -484,32 +493,29 @@ public class EditorPanel {
 		}
 	}
 
-	public void setHighlightedTokens(Map<TokenType, ? extends Collection<Token>> tokens) {
+	public void setHighlightedTokens(TokenStore tokenStore, Map<TokenType, ? extends Collection<Token>> tokens) {
 		// remove any old highlighters
 		this.editor.getHighlighter().removeAllHighlights();
 
-		if (this.boxHighlightPainters != null) {
-			BoxHighlightPainter proposedPainter = this.boxHighlightPainters.get(TokenType.JAR_PROPOSED);
+		for (TokenType type : tokens.keySet()) {
+			BoxHighlightPainter tokenPainter = switch (type) {
+				case OBFUSCATED -> this.obfuscatedPainter;
+				case DEOBFUSCATED -> this.deobfuscatedPainter;
+				case DEBUG -> this.debugPainter;
+				case JAR_PROPOSED, DYNAMIC_PROPOSED -> this.proposedPainter;
+			};
 
-			for (TokenType type : tokens.keySet()) {
-				BoxHighlightPainter painter = this.boxHighlightPainters.get(type);
+			for (Token token : tokens.get(type)) {
+				EntryReference<Entry<?>, Entry<?>> reference = this.getReference(token);
 
-				if (painter != null) {
-					for (Token token : tokens.get(type)) {
-						EntryReference<Entry<?>, Entry<?>> reference = this.getReference(token);
-						BoxHighlightPainter tokenPainter;
-
-						if (reference != null) {
-							EditableType t = EditableType.fromEntry(reference.entry);
-							boolean editable = t == null || this.gui.isEditable(t);
-							tokenPainter = editable ? painter : proposedPainter;
-						} else {
-							tokenPainter = painter;
-						}
-
-						this.addHighlightedToken(token, tokenPainter);
-					}
+				if (reference != null) {
+					EditableType t = EditableType.fromEntry(reference.entry);
+					boolean editable = t == null || this.gui.isEditable(t);
+					boolean fallback = tokenStore.isFallback(token);
+					tokenPainter = editable ? (fallback ? this.fallbackPainter : tokenPainter) : this.proposedPainter;
 				}
+
+				this.addHighlightedToken(token, tokenPainter);
 			}
 		}
 

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
@@ -498,7 +498,7 @@ public class EditorPanel {
 		this.editor.getHighlighter().removeAllHighlights();
 
 		for (TokenType type : tokens.keySet()) {
-			BoxHighlightPainter tokenPainter = switch (type) {
+			BoxHighlightPainter typePainter = switch (type) {
 				case OBFUSCATED -> this.obfuscatedPainter;
 				case DEOBFUSCATED -> this.deobfuscatedPainter;
 				case DEBUG -> this.debugPainter;
@@ -506,13 +506,14 @@ public class EditorPanel {
 			};
 
 			for (Token token : tokens.get(type)) {
+				BoxHighlightPainter tokenPainter = typePainter;
 				EntryReference<Entry<?>, Entry<?>> reference = this.getReference(token);
 
 				if (reference != null) {
 					EditableType t = EditableType.fromEntry(reference.entry);
 					boolean editable = t == null || this.gui.isEditable(t);
 					boolean fallback = tokenStore.isFallback(token);
-					tokenPainter = editable ? (fallback ? this.fallbackPainter : tokenPainter) : this.proposedPainter;
+					tokenPainter = editable ? (fallback ? this.fallbackPainter : typePainter) : this.proposedPainter;
 				}
 
 				this.addHighlightedToken(token, tokenPainter);

--- a/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
@@ -197,6 +197,22 @@ public class Enigma {
 		return this.parseFileType(path).flatMap(this::getReadWriteService);
 	}
 
+	/**
+	 * Searches for and returns a service with a matching id to the provided {@code id}.
+	 * @param type the type of the searched service
+	 * @param id the id of the service
+	 * @return the optional service
+	 */
+	public <T extends EnigmaService> Optional<T> getService(EnigmaServiceType<T> type, String id) {
+		for (T service : this.services.get(type)) {
+			if (service.getId().equals(id)) {
+				return Optional.of(service);
+			}
+		}
+
+		return Optional.empty();
+	}
+
 	public static void validatePluginId(String id) {
 		if (id != null && !id.matches("([a-z0-9_]+):([a-z0-9_]+((/[a-z0-9_]+)+)?)")) {
 			throw new IllegalArgumentException("Invalid plugin id: \"" + id + "\"\n" + "Refer to Javadoc on EnigmaService#getId for how to properly form a service ID.");

--- a/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
@@ -107,7 +107,7 @@ public class Enigma {
 
 			if (proposed != null) {
 				for (var entry : proposed.entrySet()) {
-					if (entry.getValue() != null && entry.getValue().tokenType() != TokenType.JAR_PROPOSED) {
+					if (!service.bypassValidation() && entry.getValue() != null && entry.getValue().tokenType() != TokenType.JAR_PROPOSED) {
 						throw new RuntimeException("Token type of mapping " + entry.getValue() + " for entry " + entry.getKey() + " was " + entry.getValue().tokenType() + ", but should be " + TokenType.JAR_PROPOSED + "!");
 					}
 

--- a/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/Enigma.java
@@ -326,7 +326,7 @@ public class Enigma {
 
 			for (EnigmaProfile.Service serviceProfile : serviceProfiles) {
 				T service = factory.create(this.getServiceContext(serviceProfile));
-				if (serviceProfile.matches(service.getId())) {
+				if (serviceProfile != null && serviceProfile.matches(service.getId())) {
 					this.putService(serviceType, service);
 					break;
 				}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProject.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProject.java
@@ -271,8 +271,8 @@ public class EnigmaProject {
 			ClassNode classNode = this.getClassProvider().get(parentClass.getFullName());
 			if (classNode != null) {
 				classNode.methods.stream()
-					.filter(node -> node.name.equals(parent.getName()) && node.desc.equals(parent.getDesc().toString()))
-					.findFirst().ifPresent(node -> maxLocals.set(node.maxLocals));
+						.filter(node -> node.name.equals(parent.getName()) && node.desc.equals(parent.getDesc().toString()))
+						.findFirst().ifPresent(node -> maxLocals.set(node.maxLocals));
 			}
 
 			// if maxLocals is -1 it's not found for the method and should be ignored

--- a/enigma/src/main/java/org/quiltmc/enigma/api/service/NameProposalService.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/service/NameProposalService.java
@@ -42,6 +42,14 @@ public interface NameProposalService extends EnigmaService {
 	@Nullable
 	Map<Entry<?>, EntryMapping> getDynamicProposedNames(EntryRemapper remapper, @Nullable Entry<?> obfEntry, @Nullable EntryMapping oldMapping, @Nullable EntryMapping newMapping);
 
+	default boolean isFallback() {
+		return false;
+	}
+
+	default boolean alwaysSave() {
+		return false;
+	}
+
 	/**
 	 * Creates a proposed mapping, with no javadoc and using {@link #getId()} as the source plugin ID.
 	 * @param name the name

--- a/enigma/src/main/java/org/quiltmc/enigma/api/service/NameProposalService.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/service/NameProposalService.java
@@ -46,7 +46,15 @@ public interface NameProposalService extends EnigmaService {
 		return false;
 	}
 
-	default boolean alwaysSave() {
+	/**
+	 * Disables validation of proposed mappings from this service.
+	 * This allows you to return any kind of mapping you want from {@link #getDynamicProposedNames(EntryRemapper, Entry, EntryMapping, EntryMapping)}
+	 * and {@link #getProposedNames(JarIndex)}, but should be used sparingly as it will allow creating mappings that can't be linked back to this proposer.
+	 * Do not use this unless you're sure there's no other way to accomplish what you're looking to do!
+	 *
+	 * @return whether validation should be bypassed
+	 */
+	default boolean bypassValidation() {
 		return false;
 	}
 

--- a/enigma/src/main/java/org/quiltmc/enigma/api/source/DecompiledClassSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/source/DecompiledClassSource.java
@@ -57,7 +57,7 @@ public class DecompiledClassSource {
 		TranslateResult<Entry<?>> translatedEntry = translator.extendedTranslate(entry);
 
 		if (project.isRenamable(reference)) {
-			if (!translatedEntry.isObfuscated()) {
+			if (translatedEntry != null && !translatedEntry.isObfuscated()) {
 				target.add(translatedEntry.getType(), movedToken);
 				return translatedEntry.getValue().getSourceRemapName();
 			} else {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/source/DecompiledClassSource.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/source/DecompiledClassSource.java
@@ -4,6 +4,7 @@ import org.quiltmc.enigma.api.EnigmaProject;
 import org.quiltmc.enigma.api.analysis.EntryReference;
 import org.quiltmc.enigma.api.translation.TranslateResult;
 import org.quiltmc.enigma.api.translation.Translator;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.representation.TypeDescriptor;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
@@ -58,13 +59,13 @@ public class DecompiledClassSource {
 
 		if (project.isRenamable(reference)) {
 			if (translatedEntry != null && !translatedEntry.isObfuscated()) {
-				target.add(translatedEntry.getType(), movedToken);
+				target.add(project, translatedEntry.getMapping(), movedToken);
 				return translatedEntry.getValue().getSourceRemapName();
 			} else {
-				target.add(TokenType.OBFUSCATED, movedToken);
+				target.add(project, EntryMapping.OBFUSCATED, movedToken);
 			}
 		} else if (DEBUG_TOKEN_HIGHLIGHTS) {
-			target.add(TokenType.DEBUG, movedToken);
+			target.add(project, new EntryMapping(null, null, TokenType.DEBUG, null), movedToken);
 		}
 
 		return this.generateDefaultName(translatedEntry.getValue());

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/TranslateResult.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/TranslateResult.java
@@ -1,57 +1,100 @@
 package org.quiltmc.enigma.api.translation;
 
 import org.quiltmc.enigma.api.source.TokenType;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 
 import java.util.Objects;
 import java.util.function.Function;
 
-public final class TranslateResult<T> {
-	private final TokenType type;
+/**
+ * Represents the result of a translation operation on an arbitrary object.
+ * @param <T> the type of the translated object
+ */
+public final class TranslateResult<T extends Translatable> {
+	private final EntryMapping mapping;
 	private final T value;
 
-	private TranslateResult(TokenType type, T value) {
-		this.type = type;
+	private TranslateResult(EntryMapping mapping, T value) {
+		this.mapping = mapping;
 		this.value = value;
 	}
 
-	public static <T> TranslateResult<T> of(TokenType type, T value) {
-		Objects.requireNonNull(type, "type must not be null");
-		return new TranslateResult<>(type, value);
+	/**
+	 * Creates a translation result for the given value.
+	 * @param mapping the value's mapping
+	 * @param value the translated value
+	 * @return a result containing that value
+	 */
+	public static <T extends Translatable> TranslateResult<T> of(EntryMapping mapping, T value) {
+		Objects.requireNonNull(mapping, "mapping must not be null");
+		return new TranslateResult<>(mapping, value);
 	}
 
-	// Used for translatables that don't have a concept of
-	// obfuscated/deobfuscated (e.g. method descriptors) for example because
-	// they don't have an identifier attached to them
-	public static <T> TranslateResult<T> ungrouped(T value) {
+	/**
+	 * Creates a translation result for values that cannot have an attached mapping, such as method descriptors.
+	 * @param value the translated value
+	 * @return a result containing that value
+	 */
+	public static <T extends Translatable> TranslateResult<T> ungrouped(T value) {
 		return TranslateResult.obfuscated(value);
 	}
 
-	public static <T> TranslateResult<T> obfuscated(T value) {
-		return TranslateResult.of(TokenType.OBFUSCATED, value);
+	/**
+	 * Creates an obfuscated translation result.
+	 * @param value the obfuscated value
+	 * @return a result containing that value
+	 */
+	public static <T extends Translatable> TranslateResult<T> obfuscated(T value) {
+		return TranslateResult.of(EntryMapping.OBFUSCATED, value);
 	}
 
-	public static <T> TranslateResult<T> deobfuscated(T value) {
-		return TranslateResult.of(TokenType.DEOBFUSCATED, value);
-	}
-
+	/**
+	 * {@return the token type of the result mapping}
+	 */
 	public TokenType getType() {
-		return this.type;
+		return this.mapping.tokenType();
 	}
 
+	/**
+	 * {@return the result mapping}
+	 */
+	public EntryMapping getMapping() {
+		return this.mapping;
+	}
+
+	/**
+	 * {@return the translated value}
+	 */
 	public T getValue() {
 		return this.value;
 	}
 
-	public <R> TranslateResult<R> map(Function<T, R> op) {
-		return TranslateResult.of(this.type, op.apply(this.value));
-	}
-
+	/**
+	 * {@return whether this result is obfuscated}
+	 */
 	public boolean isObfuscated() {
-		return this.type == TokenType.OBFUSCATED;
+		return this.getType() == TokenType.OBFUSCATED;
 	}
 
+	/**
+	 * {@return whether this result is manually mapped}
+	 *
+	 * @deprecated for removal in 3.0.0. This method's name is misleading, as it does not check that the mapping is not obfuscated, it checks whether the token type is equal to
+	 * {@link TokenType#DEOBFUSCATED}, which equates to a manual mapping. For the old behaviour, you can manually compare {@link #getType()} with {@link TokenType#DEOBFUSCATED}.
+	 * In order to check that the mapping is not obfuscated, use {@code !}{@link #isObfuscated()}.
+	 */
+	@Deprecated(forRemoval = true, since = "2.6.0")
 	public boolean isDeobfuscated() {
-		return this.type == TokenType.DEOBFUSCATED;
+		return this.getType() == TokenType.DEOBFUSCATED;
+	}
+
+	/**
+	 * Creates a new result, applying {@code op} to the {@link #value} without changing the {@link #mapping}.
+	 * @param op the operation to apply to the current value
+	 * @return the new result
+	 */
+	public <R extends Translatable> TranslateResult<R> map(Function<T, R> op) {
+		return TranslateResult.of(this.mapping, op.apply(this.value));
 	}
 
 	@Override
@@ -59,17 +102,16 @@ public final class TranslateResult<T> {
 		if (this == o) return true;
 		if (o == null || this.getClass() != o.getClass()) return false;
 		TranslateResult<?> that = (TranslateResult<?>) o;
-		return this.type == that.type
-				&& Objects.equals(this.value, that.value);
+		return Objects.equals(this.mapping, that.mapping) && Objects.equals(this.value, that.value);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.type, this.value);
+		return Objects.hash(this.mapping, this.value);
 	}
 
 	@Override
 	public String toString() {
-		return String.format("TranslateResult { type: %s, value: %s }", this.type, this.value);
+		return String.format("TranslateResult { mapping: %s, value: %s }", this.mapping, this.value);
 	}
 }

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
@@ -4,6 +4,7 @@ import org.quiltmc.enigma.api.analysis.index.jar.InheritanceIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.analysis.index.mapping.MappingsIndex;
 import org.quiltmc.enigma.api.service.NameProposalService;
+import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.api.translation.MappingTranslator;
 import org.quiltmc.enigma.api.translation.Translatable;
 import org.quiltmc.enigma.api.translation.TranslateResult;
@@ -143,11 +144,12 @@ public class EntryRemapper {
 			var proposedNames = service.getDynamicProposedNames(this, obfEntry, oldMapping, newMapping);
 			if (proposedNames != null) {
 				// due to unchecked proposal, proposers are allowed to insert other token types
+				// when deobfuscated, they must be put in the main tree
 				proposedNames.forEach((entry, mapping) -> {
-					if (mapping.tokenType().isProposed()) {
-						this.proposedMappings.insert(entry, mapping);
-					} else {
+					if (mapping.tokenType() == TokenType.DEOBFUSCATED) {
 						this.mappings.insert(entry, mapping);
+					} else {
+						this.proposedMappings.insert(entry, mapping);
 					}
 				});
 			}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryRemapper.java
@@ -142,7 +142,14 @@ public class EntryRemapper {
 		for (var service : this.proposalServices) {
 			var proposedNames = service.getDynamicProposedNames(this, obfEntry, oldMapping, newMapping);
 			if (proposedNames != null) {
-				proposedNames.forEach(this.proposedMappings::insert);
+				// due to unchecked proposal, proposers are allowed to insert other token types
+				proposedNames.forEach((entry, mapping) -> {
+					if (mapping.tokenType().isProposed()) {
+						this.proposedMappings.insert(entry, mapping);
+					} else {
+						this.mappings.insert(entry, mapping);
+					}
+				});
 			}
 		}
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/Lambda.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/Lambda.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.api.translation.representation;
 
-import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.api.translation.Translatable;
 import org.quiltmc.enigma.api.translation.TranslateResult;
 import org.quiltmc.enigma.api.translation.Translator;
@@ -21,7 +20,7 @@ public record Lambda(String invokedName, MethodDescriptor invokedType, MethodDes
 		EntryMapping samMethodMapping = this.resolveMapping(resolver, mappings, samMethod);
 
 		return TranslateResult.of(
-				samMethodMapping.targetName() == null ? TokenType.OBFUSCATED : TokenType.DEOBFUSCATED,
+				samMethodMapping,
 				new Lambda(
 						samMethodMapping.targetName() != null ? samMethodMapping.targetName() : this.invokedName,
 						this.invokedType.extendedTranslate(translator, resolver, mappings).getValue(),

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/ClassDefEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/ClassDefEntry.java
@@ -77,7 +77,7 @@ public class ClassDefEntry extends ClassEntry implements DefEntry<ClassEntry> {
 		ClassEntry[] translatedInterfaces = Arrays.stream(this.interfaces).map(translator::translate).toArray(ClassEntry[]::new);
 		String docs = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new ClassDefEntry(this.parent, translatedName, translatedSignature, this.access, translatedSuper, translatedInterfaces, docs)
 		);
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/ClassEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/ClassEntry.java
@@ -80,7 +80,7 @@ public class ClassEntry extends ParentedEntry<ClassEntry> implements Comparable<
 		String translatedName = mapping.targetName() != null ? mapping.targetName() : this.name;
 		String docs = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new ClassEntry(this.parent, translatedName, docs)
 		);
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/FieldDefEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/FieldDefEntry.java
@@ -46,7 +46,7 @@ public class FieldDefEntry extends FieldEntry implements DefEntry<ClassEntry> {
 		String translatedName = mapping.targetName() != null ? mapping.targetName() : this.name;
 		String docs = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new FieldDefEntry(this.parent, translatedName, translatedDesc, translatedSignature, this.access, docs)
 		);
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/FieldEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/FieldEntry.java
@@ -53,7 +53,7 @@ public class FieldEntry extends ParentedEntry<ClassEntry> implements Comparable<
 		String translatedName = mapping.targetName() != null ? mapping.targetName() : this.name;
 		String docs = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new FieldEntry(this.parent, translatedName, translator.translate(this.desc), docs)
 		);
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/LocalVariableDefEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/LocalVariableDefEntry.java
@@ -28,7 +28,7 @@ public class LocalVariableDefEntry extends LocalVariableEntry {
 		String translatedName = mapping.targetName() != null ? mapping.targetName() : this.name;
 		String javadoc = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new LocalVariableDefEntry(this.parent, this.index, translatedName, this.parameter, translatedDesc, javadoc)
 		);
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/LocalVariableEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/LocalVariableEntry.java
@@ -44,7 +44,7 @@ public class LocalVariableEntry extends ParentedEntry<MethodEntry> implements Co
 		String translatedName = mapping.targetName() != null ? mapping.targetName() : this.name;
 		String javadoc = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new LocalVariableEntry(this.parent, this.index, translatedName, this.parameter, javadoc)
 		);
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/MethodDefEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/MethodDefEntry.java
@@ -46,7 +46,7 @@ public class MethodDefEntry extends MethodEntry implements DefEntry<ClassEntry> 
 		String translatedName = mapping.targetName() != null ? mapping.targetName() : this.name;
 		String docs = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new MethodDefEntry(this.parent, translatedName, translatedDesc, translatedSignature, this.access, docs)
 		);
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/MethodEntry.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/representation/entry/MethodEntry.java
@@ -97,7 +97,7 @@ public class MethodEntry extends ParentedEntry<ClassEntry> implements Comparable
 		String translatedName = mapping.targetName() != null ? mapping.targetName() : this.name;
 		String docs = mapping.javadoc();
 		return TranslateResult.of(
-				mapping.tokenType(),
+				mapping,
 				new MethodEntry(this.parent, translatedName, translator.translate(this.descriptor), docs)
 		);
 	}

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
@@ -14,14 +14,12 @@ import org.quiltmc.enigma.api.analysis.index.jar.EntryIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
 import org.quiltmc.enigma.api.service.NameProposalService;
-import org.quiltmc.enigma.api.service.ReadWriteService;
 import org.quiltmc.enigma.api.source.TokenType;
 import org.quiltmc.enigma.api.stats.StatType;
 import org.quiltmc.enigma.api.stats.StatsGenerator;
 import org.quiltmc.enigma.api.translation.TranslateResult;
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
-import org.quiltmc.enigma.api.translation.mapping.serde.MappingParseException;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 import org.quiltmc.enigma.impl.plugin.BuiltinPlugin;
@@ -73,7 +71,7 @@ public class TestFallbackNameProposal {
 	}
 
 	@Test
-	public void testFallbackStats() throws IOException, MappingParseException {
+	public void testFallbackStats() throws IOException {
 		ClassEntry bClass = TestEntryFactory.newClass("b");
 
 		// assert a couple mappings to make sure the test plugin works
@@ -104,7 +102,7 @@ public class TestFallbackNameProposal {
 
 	// todo: ui test for colour?
 
-	private void assertMappingStartsWith(Entry<?> obf, Entry<?> deobf) {
+	private static void assertMappingStartsWith(Entry<?> obf, Entry<?> deobf) {
 		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
 		assertThat(result, is(notNullValue()));
 
@@ -112,17 +110,6 @@ public class TestFallbackNameProposal {
 		if (deobfName != null) {
 			assertThat(deobfName, startsWith(deobf.getName()));
 		}
-	}
-
-	private void assertUnmapped(Entry<?> obf) {
-		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
-		assertThat(result, is(notNullValue()));
-		assertThat(result.getType(), is(TokenType.OBFUSCATED));
-	}
-
-	@SuppressWarnings("all")
-	private ReadWriteService getService() {
-		return project.getEnigma().getReadWriteService(project.getEnigma().getSupportedFileTypes().stream().filter(file -> file.getExtensions().contains("mapping") && !file.isDirectory()).findFirst().get()).get();
 	}
 
 	private static class TestPlugin implements EnigmaPlugin {
@@ -139,7 +126,7 @@ public class TestFallbackNameProposal {
 				AtomicInteger i = new AtomicInteger();
 
 				index.getIndex(EntryIndex.class).getFields().forEach(
-					field -> mappings.put(field, this.createMapping("slay" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+						field -> mappings.put(field, this.createMapping("slay" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
 				);
 
 				return mappings;
@@ -163,7 +150,7 @@ public class TestFallbackNameProposal {
 				AtomicInteger i = new AtomicInteger();
 
 				index.getIndex(EntryIndex.class).getMethods().forEach(
-					method -> mappings.put(method, this.createMapping("gaming" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+						method -> mappings.put(method, this.createMapping("gaming" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
 				);
 
 				return mappings;

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
@@ -1,5 +1,188 @@
 package org.quiltmc.enigma.name_proposal;
 
-public class TestFallbackNameProposal {
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.enigma.TestEntryFactory;
+import org.quiltmc.enigma.TestUtil;
+import org.quiltmc.enigma.api.Enigma;
+import org.quiltmc.enigma.api.EnigmaPlugin;
+import org.quiltmc.enigma.api.EnigmaPluginContext;
+import org.quiltmc.enigma.api.EnigmaProfile;
+import org.quiltmc.enigma.api.EnigmaProject;
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.analysis.index.jar.EntryIndex;
+import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
+import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
+import org.quiltmc.enigma.api.service.NameProposalService;
+import org.quiltmc.enigma.api.service.ReadWriteService;
+import org.quiltmc.enigma.api.source.TokenType;
+import org.quiltmc.enigma.api.stats.StatType;
+import org.quiltmc.enigma.api.stats.StatsGenerator;
+import org.quiltmc.enigma.api.translation.TranslateResult;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingParseException;
+import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.impl.plugin.BuiltinPlugin;
+import org.tinylog.Logger;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestFallbackNameProposal {
+	private static final Path JAR = TestUtil.obfJar("validation");
+	private static EnigmaProject project;
+
+	@BeforeAll
+	public static void setupEnigma() {
+		Reader r = new StringReader("""
+				{
+					"services": {
+						"name_proposal": [
+							{
+								"id": "test:name_all_fields_slay"
+							},
+							{
+								"id": "test:name_all_methods_gaming"
+							}
+						]
+					}
+				}""");
+
+		try {
+			EnigmaProfile profile = EnigmaProfile.parse(r);
+			Enigma enigma = Enigma.builder().setProfile(profile).setPlugins(List.of(new BuiltinPlugin(), new TestPlugin())).build();
+			project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+		} catch (Exception e) {
+			Logger.error(e, "Failed to open jar!");
+		}
+	}
+
+	@Test
+	public void testFallbackStats() throws IOException, MappingParseException {
+		ClassEntry bClass = TestEntryFactory.newClass("b");
+
+		// assert a couple mappings to make sure the test plugin works
+		assertMappingStartsWith(TestEntryFactory.newMethod(bClass, "c", "()V"), TestEntryFactory.newMethod(bClass, "gaming", "()V"));
+		assertMappingStartsWith(TestEntryFactory.newMethod(bClass, "a", "(I)V"), TestEntryFactory.newMethod(bClass, "gaming", "(I)V"));
+
+		assertMappingStartsWith(TestEntryFactory.newField(bClass, "a", "I"), TestEntryFactory.newField(bClass, "slay", "I"));
+		assertMappingStartsWith(TestEntryFactory.newField(bClass, "a", "Ljava/lang/String;"), TestEntryFactory.newField(bClass, "slay", "Ljava/lang/String;"));
+
+		var proposerFieldStats = new StatsGenerator(project).generate(ProgressListener.createEmpty(), Set.of(StatType.FIELDS), bClass, false);
+		var proposerMethodStats = new StatsGenerator(project).generate(ProgressListener.createEmpty(), Set.of(StatType.METHODS), bClass, false);
+
+		project = Enigma.create().openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+
+		var controlFieldStats = new StatsGenerator(project).generate(ProgressListener.createEmpty(), Set.of(StatType.FIELDS), bClass, false);
+		var controlMethodStats = new StatsGenerator(project).generate(ProgressListener.createEmpty(), Set.of(StatType.METHODS), bClass, false);
+
+		// method stats should be identical since fallback proposals don't affect stats
+		assertEquals(controlMethodStats.getMappable(), proposerMethodStats.getMappable());
+		assertEquals(controlMethodStats.getMapped(), proposerMethodStats.getMapped());
+		assertEquals(controlMethodStats.getUnmapped(), proposerMethodStats.getUnmapped());
+
+		// field stats should be fully mapped when proposed -- normal behaviour
+		assertEquals(controlFieldStats.getMappable(), proposerFieldStats.getMappable());
+		assertEquals(0, proposerFieldStats.getUnmapped());
+		assertEquals(controlFieldStats.getMappable(), proposerFieldStats.getMapped());
+	}
+
+	// todo: ui test for colour?
+
+	private void assertMappingStartsWith(Entry<?> obf, Entry<?> deobf) {
+		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
+		assertThat(result, is(notNullValue()));
+
+		String deobfName = result.getValue().getName();
+		if (deobfName != null) {
+			assertThat(deobfName, startsWith(deobf.getName()));
+		}
+	}
+
+	private void assertUnmapped(Entry<?> obf) {
+		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
+		assertThat(result, is(notNullValue()));
+		assertThat(result.getType(), is(TokenType.OBFUSCATED));
+	}
+
+	@SuppressWarnings("all")
+	private ReadWriteService getService() {
+		return project.getEnigma().getReadWriteService(project.getEnigma().getSupportedFileTypes().stream().filter(file -> file.getExtensions().contains("mapping") && !file.isDirectory()).findFirst().get()).get();
+	}
+
+	private static class TestPlugin implements EnigmaPlugin {
+		@Override
+		public void init(EnigmaPluginContext ctx) {
+			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestPlugin.TestFieldProposerNoFallback());
+			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestPlugin.TestMethodProposerWithFallback());
+		}
+
+		private static class TestFieldProposerNoFallback implements NameProposalService {
+			@Override
+			public Map<Entry<?>, EntryMapping> getProposedNames(JarIndex index) {
+				Map<Entry<?>, EntryMapping> mappings = new HashMap<>();
+				AtomicInteger i = new AtomicInteger();
+
+				index.getIndex(EntryIndex.class).getFields().forEach(
+					field -> mappings.put(field, this.createMapping("slay" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+				);
+
+				return mappings;
+			}
+
+			@Override
+			public Map<Entry<?>, EntryMapping> getDynamicProposedNames(EntryRemapper remapper, @Nullable Entry<?> obfEntry, @Nullable EntryMapping oldMapping, @Nullable EntryMapping newMapping) {
+				return null;
+			}
+
+			@Override
+			public String getId() {
+				return "test:name_all_fields_slay";
+			}
+		}
+
+		private static class TestMethodProposerWithFallback implements NameProposalService {
+			@Override
+			public Map<Entry<?>, EntryMapping> getProposedNames(JarIndex index) {
+				Map<Entry<?>, EntryMapping> mappings = new HashMap<>();
+				AtomicInteger i = new AtomicInteger();
+
+				index.getIndex(EntryIndex.class).getMethods().forEach(
+					method -> mappings.put(method, this.createMapping("gaming" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+				);
+
+				return mappings;
+			}
+
+			@Override
+			public Map<Entry<?>, EntryMapping> getDynamicProposedNames(EntryRemapper remapper, @Nullable Entry<?> obfEntry, @Nullable EntryMapping oldMapping, @Nullable EntryMapping newMapping) {
+				return null;
+			}
+
+			@Override
+			public boolean isFallback() {
+				return true;
+			}
+
+			@Override
+			public String getId() {
+				return "test:name_all_methods_gaming";
+			}
+		}
+	}
 }

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
@@ -1,0 +1,5 @@
+package org.quiltmc.enigma.name_proposal;
+
+public class TestFallbackNameProposal {
+
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestFallbackNameProposal.java
@@ -23,7 +23,6 @@ import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 import org.quiltmc.enigma.impl.plugin.BuiltinPlugin;
-import org.tinylog.Logger;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -66,7 +65,7 @@ public class TestFallbackNameProposal {
 			Enigma enigma = Enigma.builder().setProfile(profile).setPlugins(List.of(new BuiltinPlugin(), new TestPlugin())).build();
 			project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
 		} catch (Exception e) {
-			Logger.error(e, "Failed to open jar!");
+			throw new RuntimeException("Failed to open jar!", e);
 		}
 	}
 
@@ -99,8 +98,6 @@ public class TestFallbackNameProposal {
 		assertEquals(0, proposerFieldStats.getUnmapped());
 		assertEquals(controlFieldStats.getMappable(), proposerFieldStats.getMapped());
 	}
-
-	// todo: ui test for colour?
 
 	private static void assertMappingStartsWith(Entry<?> obf, Entry<?> deobf) {
 		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalAlwaysSave.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalAlwaysSave.java
@@ -167,6 +167,11 @@ public class TestNameProposalAlwaysSave {
 			}
 
 			@Override
+			public boolean alwaysSave() {
+				return true;
+			}
+
+			@Override
 			public String getId() {
 				return "test:name_all_methods_gaming";
 			}

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalAlwaysSave.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalAlwaysSave.java
@@ -1,0 +1,175 @@
+package org.quiltmc.enigma.name_proposal;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.enigma.TestEntryFactory;
+import org.quiltmc.enigma.TestUtil;
+import org.quiltmc.enigma.api.Enigma;
+import org.quiltmc.enigma.api.EnigmaPlugin;
+import org.quiltmc.enigma.api.EnigmaPluginContext;
+import org.quiltmc.enigma.api.EnigmaProfile;
+import org.quiltmc.enigma.api.EnigmaProject;
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.analysis.index.jar.EntryIndex;
+import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
+import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
+import org.quiltmc.enigma.api.service.NameProposalService;
+import org.quiltmc.enigma.api.service.ReadWriteService;
+import org.quiltmc.enigma.api.source.TokenType;
+import org.quiltmc.enigma.api.translation.TranslateResult;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingFileNameFormat;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingParseException;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
+import org.quiltmc.enigma.api.translation.representation.entry.Entry;
+import org.quiltmc.enigma.impl.plugin.BuiltinPlugin;
+import org.tinylog.Logger;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class TestNameProposalAlwaysSave {
+	private static final Path JAR = TestUtil.obfJar("validation");
+	private static EnigmaProject project;
+
+	@BeforeAll
+	public static void setupEnigma() {
+		Reader r = new StringReader("""
+				{
+					"services": {
+						"name_proposal": [
+							{
+								"id": "test:name_all_fields_slay"
+							},
+							{
+								"id": "test:name_all_methods_gaming"
+							}
+						]
+					}
+				}""");
+
+		try {
+			EnigmaProfile profile = EnigmaProfile.parse(r);
+			Enigma enigma = Enigma.builder().setProfile(profile).setPlugins(List.of(new BuiltinPlugin(), new TestPlugin())).build();
+			project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+		} catch (Exception e) {
+			Logger.error(e, "Failed to open jar!");
+		}
+	}
+
+	@Test
+	public void test() throws IOException, MappingParseException {
+		// assert a couple mappings to make sure the test plugin works
+		assertMappingStartsWith(TestEntryFactory.newMethod("b", "c", "()V"), TestEntryFactory.newMethod("b", "gaming", "()V"));
+		assertMappingStartsWith(TestEntryFactory.newMethod("b", "a", "(I)V"), TestEntryFactory.newMethod("b", "gaming", "(I)V"));
+
+		assertMappingStartsWith(TestEntryFactory.newField("b", "a", "I"), TestEntryFactory.newField("b", "slay", "I"));
+		assertMappingStartsWith(TestEntryFactory.newField("b", "a", "Ljava/lang/String;"), TestEntryFactory.newField("b", "slay", "Ljava/lang/String;"));
+
+		// save mappings to temp file
+		Path tempFile = Files.createTempFile("temp", ".mapping");
+		var service = getService();
+		service.write(project.getRemapper().getMappings(), tempFile, new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF, false, null, null));
+
+		// replace project with one that does not have the test plugin
+		Enigma enigma = Enigma.create();
+		project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+		project.setMappings(service.read(tempFile), ProgressListener.createEmpty());
+
+		// check which mappings saved
+		assertUnmapped(TestEntryFactory.newField("b", "a", "I"));
+		assertUnmapped(TestEntryFactory.newField("b", "a", "Ljava/lang/String;"));
+
+		assertMappingStartsWith(TestEntryFactory.newMethod("b", "c", "()V"), TestEntryFactory.newMethod("b", "gaming", "()V"));
+		assertMappingStartsWith(TestEntryFactory.newMethod("b", "a", "(I)V"), TestEntryFactory.newMethod("b", "gaming", "(I)V"));
+	}
+
+	private void assertMappingStartsWith(Entry<?> obf, Entry<?> deobf) {
+		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
+		assertThat(result, is(notNullValue()));
+
+		String deobfName = result.getValue().getName();
+		if (deobfName != null) {
+			assertThat(deobfName, startsWith(deobf.getName()));
+		}
+	}
+
+	private void assertUnmapped(Entry<?> obf) {
+		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
+		assertThat(result, is(notNullValue()));
+		assertThat(result.getType(), is(TokenType.OBFUSCATED));
+	}
+
+	@SuppressWarnings("all")
+	private ReadWriteService getService() {
+		return project.getEnigma().getReadWriteService(project.getEnigma().getSupportedFileTypes().stream().filter(file -> file.getExtensions().contains("mapping") && !file.isDirectory()).findFirst().get()).get();
+	}
+
+	private static class TestPlugin implements EnigmaPlugin {
+		@Override
+		public void init(EnigmaPluginContext ctx) {
+			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestFieldProposerNoFallback());
+			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestMethodProposerWithFallback());
+		}
+
+		private static class TestFieldProposerNoFallback implements NameProposalService {
+			@Override
+			public Map<Entry<?>, EntryMapping> getProposedNames(JarIndex index) {
+				Map<Entry<?>, EntryMapping> mappings = new HashMap<>();
+				AtomicInteger i = new AtomicInteger();
+
+				index.getIndex(EntryIndex.class).getFields().forEach(
+					field -> mappings.put(field, this.createMapping("slay" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+				);
+
+				return mappings;
+			}
+
+			@Override
+			public Map<Entry<?>, EntryMapping> getDynamicProposedNames(EntryRemapper remapper, @Nullable Entry<?> obfEntry, @Nullable EntryMapping oldMapping, @Nullable EntryMapping newMapping) {
+				return null;
+			}
+
+			@Override
+			public String getId() {
+				return "test:name_all_fields_slay";
+			}
+		}
+
+		private static class TestMethodProposerWithFallback implements NameProposalService {
+			@Override
+			public Map<Entry<?>, EntryMapping> getProposedNames(JarIndex index) {
+				Map<Entry<?>, EntryMapping> mappings = new HashMap<>();
+				AtomicInteger i = new AtomicInteger();
+
+				index.getIndex(EntryIndex.class).getMethods().forEach(
+					method -> mappings.put(method, this.createMapping("gaming" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+				);
+
+				return mappings;
+			}
+
+			@Override
+			public Map<Entry<?>, EntryMapping> getDynamicProposedNames(EntryRemapper remapper, @Nullable Entry<?> obfEntry, @Nullable EntryMapping oldMapping, @Nullable EntryMapping newMapping) {
+				return null;
+			}
+
+			@Override
+			public String getId() {
+				return "test:name_all_methods_gaming";
+			}
+		}
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
@@ -96,7 +96,7 @@ public class TestNameProposalBypassValidation {
 		assertMappingStartsWith(TestEntryFactory.newMethod("b", "a", "(I)V"), TestEntryFactory.newMethod("b", "gaming", "(I)V"));
 	}
 
-	private void assertMappingStartsWith(Entry<?> obf, Entry<?> deobf) {
+	private static void assertMappingStartsWith(Entry<?> obf, Entry<?> deobf) {
 		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
 		assertThat(result, is(notNullValue()));
 
@@ -106,14 +106,14 @@ public class TestNameProposalBypassValidation {
 		}
 	}
 
-	private void assertUnmapped(Entry<?> obf) {
+	private static void assertUnmapped(Entry<?> obf) {
 		TranslateResult<? extends Entry<?>> result = project.getRemapper().getDeobfuscator().extendedTranslate(obf);
 		assertThat(result, is(notNullValue()));
 		assertThat(result.getType(), is(TokenType.OBFUSCATED));
 	}
 
 	@SuppressWarnings("all")
-	private ReadWriteService getService() {
+	private static ReadWriteService getService() {
 		return project.getEnigma().getReadWriteService(project.getEnigma().getSupportedFileTypes().stream().filter(file -> file.getExtensions().contains("mapping") && !file.isDirectory()).findFirst().get()).get();
 	}
 
@@ -131,7 +131,7 @@ public class TestNameProposalBypassValidation {
 				AtomicInteger i = new AtomicInteger();
 
 				index.getIndex(EntryIndex.class).getFields().forEach(
-					field -> mappings.put(field, this.createMapping("slay" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+						field -> mappings.put(field, this.createMapping("slay" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
 				);
 
 				return mappings;
@@ -155,7 +155,7 @@ public class TestNameProposalBypassValidation {
 				AtomicInteger i = new AtomicInteger();
 
 				index.getIndex(EntryIndex.class).getMethods().forEach(
-					method -> mappings.put(method, new EntryMapping("gaming" + i.getAndIncrement(), null, TokenType.DEOBFUSCATED, null))
+						method -> mappings.put(method, new EntryMapping("gaming" + i.getAndIncrement(), null, TokenType.DEOBFUSCATED, null))
 				);
 
 				return mappings;

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
@@ -120,11 +120,11 @@ public class TestNameProposalBypassValidation {
 	private static class TestPlugin implements EnigmaPlugin {
 		@Override
 		public void init(EnigmaPluginContext ctx) {
-			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestFieldProposerNoFallback());
-			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestMethodProposerWithFallback());
+			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestFieldProposerNormal());
+			ctx.registerService(NameProposalService.TYPE, ctx1 -> new TestMethodProposerWithBypass());
 		}
 
-		private static class TestFieldProposerNoFallback implements NameProposalService {
+		private static class TestFieldProposerNormal implements NameProposalService {
 			@Override
 			public Map<Entry<?>, EntryMapping> getProposedNames(JarIndex index) {
 				Map<Entry<?>, EntryMapping> mappings = new HashMap<>();
@@ -148,7 +148,7 @@ public class TestNameProposalBypassValidation {
 			}
 		}
 
-		private static class TestMethodProposerWithFallback implements NameProposalService {
+		private static class TestMethodProposerWithBypass implements NameProposalService {
 			@Override
 			public Map<Entry<?>, EntryMapping> getProposedNames(JarIndex index) {
 				Map<Entry<?>, EntryMapping> mappings = new HashMap<>();

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
@@ -24,7 +24,6 @@ import org.quiltmc.enigma.api.translation.mapping.serde.MappingParseException;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 import org.quiltmc.enigma.impl.plugin.BuiltinPlugin;
-import org.tinylog.Logger;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -65,7 +64,7 @@ public class TestNameProposalBypassValidation {
 			Enigma enigma = Enigma.builder().setProfile(profile).setPlugins(List.of(new BuiltinPlugin(), new TestPlugin())).build();
 			project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
 		} catch (Exception e) {
-			Logger.error(e, "Failed to open jar!");
+			throw new RuntimeException("Failed to open jar!", e);
 		}
 	}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/name_proposal/TestNameProposalBypassValidation.java
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-public class TestNameProposalAlwaysSave {
+public class TestNameProposalBypassValidation {
 	private static final Path JAR = TestUtil.obfJar("validation");
 	private static EnigmaProject project;
 
@@ -155,7 +155,7 @@ public class TestNameProposalAlwaysSave {
 				AtomicInteger i = new AtomicInteger();
 
 				index.getIndex(EntryIndex.class).getMethods().forEach(
-					method -> mappings.put(method, this.createMapping("gaming" + i.getAndIncrement(), TokenType.JAR_PROPOSED))
+					method -> mappings.put(method, new EntryMapping("gaming" + i.getAndIncrement(), null, TokenType.DEOBFUSCATED, null))
 				);
 
 				return mappings;
@@ -167,7 +167,7 @@ public class TestNameProposalAlwaysSave {
 			}
 
 			@Override
-			public boolean alwaysSave() {
+			public boolean bypassValidation() {
 				return true;
 			}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/records/TestRecordComponentProposal.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/records/TestRecordComponentProposal.java
@@ -2,6 +2,7 @@ package org.quiltmc.enigma.records;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.quiltmc.enigma.TestEntryFactory;
 import org.quiltmc.enigma.TestUtil;
@@ -25,8 +26,8 @@ public class TestRecordComponentProposal {
 	private static final Path JAR = TestUtil.obfJar("records");
 	private static EnigmaProject project;
 
-	@BeforeAll
-	static void setupEnigma() throws IOException {
+	@BeforeEach
+	void setupEnigma() throws IOException {
 		Reader r = new StringReader("""
 				{
 					"services": {
@@ -55,8 +56,8 @@ public class TestRecordComponentProposal {
 		FieldEntry aField = TestEntryFactory.newField(aClass, "a", "I");
 		MethodEntry aGetter = TestEntryFactory.newMethod(aClass, "a", "()I");
 
-		Assertions.assertSame(project.getRemapper().getMapping(aField).tokenType(), TokenType.OBFUSCATED);
-		Assertions.assertSame(project.getRemapper().getMapping(aGetter).tokenType(), TokenType.OBFUSCATED);
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(aField).tokenType());
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(aGetter).tokenType());
 
 		project.getRemapper().putMapping(TestUtil.newVC(), aField, new EntryMapping("mapped"));
 
@@ -78,9 +79,9 @@ public class TestRecordComponentProposal {
 		MethodEntry fakeAGetter = TestEntryFactory.newMethod(cClass, "a", "()I");
 		MethodEntry realAGetter = TestEntryFactory.newMethod(cClass, "b", "()I");
 
-		Assertions.assertSame(project.getRemapper().getMapping(aField).tokenType(), TokenType.OBFUSCATED);
-		Assertions.assertSame(project.getRemapper().getMapping(fakeAGetter).tokenType(), TokenType.OBFUSCATED);
-		Assertions.assertSame(project.getRemapper().getMapping(realAGetter).tokenType(), TokenType.OBFUSCATED);
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(aField).tokenType());
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(fakeAGetter).tokenType());
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(realAGetter).tokenType());
 
 		project.getRemapper().putMapping(TestUtil.newVC(), aField, new EntryMapping("mapped"));
 
@@ -105,8 +106,8 @@ public class TestRecordComponentProposal {
 		FieldEntry aField = TestEntryFactory.newField(aClass, "a", "I");
 		MethodEntry aGetter = TestEntryFactory.newMethod(aClass, "a", "()I");
 
-		Assertions.assertSame(project.getRemapper().getMapping(aField).tokenType(), TokenType.OBFUSCATED);
-		Assertions.assertSame(project.getRemapper().getMapping(aGetter).tokenType(), TokenType.OBFUSCATED);
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(aField).tokenType());
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(aGetter).tokenType());
 
 		// put name, make sure getter matches
 		project.getRemapper().putMapping(TestUtil.newVC(), aField, new EntryMapping("mapped"));
@@ -132,8 +133,8 @@ public class TestRecordComponentProposal {
 		FieldEntry aField = TestEntryFactory.newField(eClass, "a", "Ljava/lang/String;");
 		MethodEntry aGetter = TestEntryFactory.newMethod(eClass, "a", "()Ljava/lang/String;");
 
-		Assertions.assertSame(project.getRemapper().getMapping(aField).tokenType(), TokenType.OBFUSCATED);
-		Assertions.assertSame(project.getRemapper().getMapping(aGetter).tokenType(), TokenType.OBFUSCATED);
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(aField).tokenType());
+		Assertions.assertSame(TokenType.OBFUSCATED, project.getRemapper().getMapping(aGetter).tokenType());
 
 		project.getRemapper().putMapping(TestUtil.newVC(), aField, new EntryMapping("mapped"));
 

--- a/enigma/src/test/java/org/quiltmc/enigma/records/TestRecordComponentProposal.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/records/TestRecordComponentProposal.java
@@ -1,7 +1,6 @@
 package org.quiltmc.enigma.records;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.quiltmc.enigma.TestEntryFactory;

--- a/enigma/src/testFixtures/resources/profile.json
+++ b/enigma/src/testFixtures/resources/profile.json
@@ -22,6 +22,9 @@
 				"id": "test:parameters"
 			},
 			{
+				"id": "test:strings"
+			},
+			{
 				"id": "enigma:record_component_proposer"
 			}
 		]


### PR DESCRIPTION
implements #239 

- adds a `bypassValidation()` boolean in `NameProposalService`
  - this boolean allows that service to ignore the regular checks performed on proposed mappings (validating that they either remove a mapping or provide a proposed mapping)
  - this is essential for part of https://github.com/QuiltMC/quilt-mappings/issues/660, since the mappings proposed for classes to apply moj packages have to be `TokenType.DEOBFUSCATED`
- adds a `fallback()` boolean to `NameProposalService`
  - fallback names will not count towards stats by default
  - fallback names will have a different colour in the UI
  - fallback names do not have their own token types, and are expected to be less reliably high-quality names than normal proposed mappings