### PR TITLE
fix drop invalid taking 2 runs to resolve a certain drop

### DIFF
--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/DropInvalidMappingsTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/DropInvalidMappingsTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 public class DropInvalidMappingsTest extends CommandTest {
 	private static final Path LONE_JAR = TestUtil.obfJar("lone_class");
 	private static final Path INNER_JAR = TestUtil.obfJar("inner_classes");
+	private static final Path ENUMS_JAR = TestUtil.obfJar("enums");
 	private static final Path INPUT_DIR = getResource("/drop_invalid_mappings/input/");
 	private static final Path EXPECTED_DIR = getResource("/drop_invalid_mappings/expected/");
 
@@ -21,6 +22,8 @@ public class DropInvalidMappingsTest extends CommandTest {
 	private static final Path MAPPING_SAVE_EXPECTED = EXPECTED_DIR.resolve("MappingSave.mapping");
 	private static final Path DISCARD_INNER_CLASS_INPUT = INPUT_DIR.resolve("DiscardInnerClass.mapping");
 	private static final Path DISCARD_INNER_CLASS_EXPECTED = EXPECTED_DIR.resolve("DiscardInnerClass.mapping");
+	private static final Path ENUMS_INPUT = INPUT_DIR.resolve("Enums.mapping");
+	private static final Path ENUMS_EXPECTED = EXPECTED_DIR.resolve("Enums.mapping");
 
 	@Test
 	public void testInvalidMappings() throws Exception {
@@ -65,6 +68,18 @@ public class DropInvalidMappingsTest extends CommandTest {
 		DropInvalidMappingsCommand.run(INNER_JAR, DISCARD_INNER_CLASS_INPUT, resultFile);
 
 		String expectedLines = Files.readString(DISCARD_INNER_CLASS_EXPECTED);
+		String actualLines = Files.readString(resultFile);
+
+		Assertions.assertEquals(expectedLines, actualLines);
+	}
+
+	@Test
+	public void testEnums() throws Exception {
+		Path resultFile = Files.createTempFile("enums", ".mapping");
+
+		DropInvalidMappingsCommand.run(ENUMS_JAR, ENUMS_INPUT, resultFile);
+
+		String expectedLines = Files.readString(ENUMS_EXPECTED);
 		String actualLines = Files.readString(resultFile);
 
 		Assertions.assertEquals(expectedLines, actualLines);

--- a/enigma-cli/src/test/resources/drop_invalid_mappings/expected/Enums.mapping
+++ b/enigma-cli/src/test/resources/drop_invalid_mappings/expected/Enums.mapping
@@ -1,0 +1,5 @@
+CLASS a Gaming
+	FIELD a wawa I
+	METHOD <init> (Ljava/lang/String;II)V
+		ARG 3 wawa
+	METHOD a wawa ()I

--- a/enigma-cli/src/test/resources/drop_invalid_mappings/input/Enums.mapping
+++ b/enigma-cli/src/test/resources/drop_invalid_mappings/input/Enums.mapping
@@ -1,0 +1,7 @@
+CLASS a Gaming
+	FIELD a wawa I
+	METHOD <init> (Ljava/lang/String;II)V
+		ARG 3 wawa
+	METHOD a wawa ()I
+	METHOD valueOf (Ljava/lang/String;)La;
+			ARG 0 name


### PR DESCRIPTION
exactly the title. this was noticed on `valueOf` methods on QM (ex. this drop requires two runs: https://github.com/QuiltMC/quilt-mappings/pull/683/files#diff-c9f1603baaaaea5f84c409bf867b7516890ec2f814826189f521eb065887ca67)

this is likely an overengineering, as i thought when starting this we already had sorting implemented. either way, i like the new structure better