### PR TITLE
Fix methods obfuscated as "new" not creating their tokens

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,1 +1,4 @@
-
+java {
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
+}

--- a/enigma-swing/src/test/resources/tinylog.properties
+++ b/enigma-swing/src/test/resources/tinylog.properties
@@ -1,0 +1,14 @@
+writingthread = true
+
+writerConsole = console
+writerConsole.format = {date: HH:mm:ss.SSS} [{level}]: {message}
+writerConsole.level = info
+
+writerFile = rolling file
+writerFile.level = trace
+writerFile.format= {date: HH:mm:ss.SSS} [{level}]: {message}
+writerFile.file = build/logs/log_{date:yyyy-MM-dd}-{count}.log
+writerFile.latest = build/logs/latest.log
+writerFile.charset = UTF-8
+writerFile.policy = daily, startup
+writirFile.backups = 10

--- a/enigma/build.gradle
+++ b/enigma/build.gradle
@@ -90,6 +90,7 @@ def registerTestJarTasks(String name, String... input) {
 		classpath configurations.proGuard
 
 		confFile = confFileArg
+		inputs.file confFileArg
 
 		libraryJars = libraryJarsArg
 

--- a/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryMapping.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/translation/mapping/EntryMapping.java
@@ -33,7 +33,7 @@ public record EntryMapping(
 			throw new RuntimeException("cannot create a mapping without a token type!");
 		} else if (tokenType == TokenType.OBFUSCATED && targetName != null) {
 			throw new RuntimeException("cannot create a named mapping with an obfuscated token type!");
-		} else if (targetName == null && tokenType != TokenType.OBFUSCATED) {
+		} else if (targetName == null && tokenType != TokenType.OBFUSCATED && tokenType != TokenType.DEBUG) {
 			throw new RuntimeException("cannot create a non-obfuscated mapping with no name!");
 		} else if (!tokenType.isProposed() && sourcePluginId != null) {
 			throw new RuntimeException("cannot create a non-proposed mapping with a source plugin ID!");

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/EnigmaDumper.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/cfr/EnigmaDumper.java
@@ -260,7 +260,7 @@ public class EnigmaDumper extends StringStreamDumper {
 		Token token = new Token(now - name.length(), now, name);
 
 		// Skip constructor references
-		if (entry != null && !name.equals("new")) {
+		if (entry != null) {
 			if (defines) {
 				this.index.addDeclaration(token, entry); // override as cfr reuses local vars
 			} else {

--- a/enigma/src/main/java/org/quiltmc/enigma/impl/source/vineflower/EnigmaTextTokenCollector.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/impl/source/vineflower/EnigmaTextTokenCollector.java
@@ -116,10 +116,6 @@ public class EnigmaTextTokenCollector extends TextTokenVisitor {
 		Token token = this.getToken(range);
 		MethodEntry entry = getMethodEntry(className, name, descriptor);
 
-		if (token.text.equals("new")) {
-			return;
-		}
-
 		if (declaration) {
 			this.addDeclaration(token, entry);
 			this.currentMethod = entry;

--- a/enigma/src/test/java/org/quiltmc/enigma/DecompilationTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/DecompilationTest.java
@@ -45,137 +45,140 @@ public class DecompilationTest {
 		// field declarations
 		for (TypeDescriptor.Primitive type : TypeDescriptor.Primitive.values()) {
 			assertThat(
-				checker.getDeclarationToken(TestEntryFactory.newField("a", type.getKeyword(), "" + type.getCode())),
-				equalTo(type.getKeyword())
+					checker.getDeclarationToken(TestEntryFactory.newField("a", type.getKeyword(), "" + type.getCode())),
+					equalTo(type.getKeyword())
 			);
 		}
 
 		List<String> fieldNames = List.of("final", "break", "for", "static", "super", "private", "import", "synchronized", "$");
 		for (String name : fieldNames) {
 			assertThat(
-				checker.getDeclarationToken(TestEntryFactory.newField("a", name, "I")),
-				equalTo(name)
+					checker.getDeclarationToken(TestEntryFactory.newField("a", name, "I")),
+					equalTo(name)
 			);
 		}
 
 		assertThat(
-			checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "transient", "C")),
-			equalTo("transient")
+				checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "transient", "C")),
+				equalTo("transient")
 		);
 		assertThat(
-			checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "volatile", "Z")),
-			equalTo("volatile")
+				checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "volatile", "Z")),
+				equalTo("volatile")
 		);
 		assertThat(
-			checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "false", "Z")),
-			equalTo("false")
+				checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "false", "Z")),
+				equalTo("false")
 		);
 
 		// method declarations
 		List<String> methodNames = List.of("new", "assert", "try", "switch", "void", "throws", "class", "while");
 		for (String name : methodNames) {
 			assertThat(
-				checker.getDeclarationToken(TestEntryFactory.newMethod("a", name, "()V")),
-				equalTo(name)
+					checker.getDeclarationToken(TestEntryFactory.newMethod("a", name, "()V")),
+					equalTo(name)
 			);
 		}
 
 		assertThat(
-			checker.getDeclarationToken(TestEntryFactory.newMethod("a", "native", "()I")),
-			equalTo("native")
+				checker.getDeclarationToken(TestEntryFactory.newMethod("a", "native", "()I")),
+				equalTo("native")
 		);
 		if (!decompiler.getId().equals("enigma:cfr")) {
 			// cfr doesnt decompile the local interface, just the local class
 			assertThat(
-				checker.getDeclarationToken(TestEntryFactory.newMethod("a$interface", "throws", "()V")),
-				equalTo("throws")
+					checker.getDeclarationToken(TestEntryFactory.newMethod("a$interface", "throws", "()V")),
+					equalTo("throws")
 			);
 			assertThat(
-				checker.getDeclarationToken(TestEntryFactory.newMethod("a$interface", "enum", "()I")),
-				equalTo("enum")
+					checker.getDeclarationToken(TestEntryFactory.newMethod("a$interface", "enum", "()I")),
+					equalTo("enum")
 			);
 		}
 
 		// class declarations
 		assertThat(
-			checker.getDeclarationToken(TestEntryFactory.newClass("a$enum")),
-			equalTo("enum")
+				checker.getDeclarationToken(TestEntryFactory.newClass("a$enum")),
+				equalTo("enum")
 		);
 		if (!decompiler.getId().equals("enigma:cfr")) {
 			assertThat(
-				checker.getDeclarationToken(TestEntryFactory.newClass("a$interface")),
-				equalTo("interface")
+					checker.getDeclarationToken(TestEntryFactory.newClass("a$interface")),
+					equalTo("interface")
 			);
 		}
+
 		assertThat(
-			checker.getDeclarationToken(TestEntryFactory.newClass("a$abstract")),
-			equalTo(decompiler.getId().equals("enigma:cfr") ? "Abstract" : "abstract") // cfr capitalizes the class for some reason
+				checker.getDeclarationToken(TestEntryFactory.newClass("a$abstract")),
+				equalTo(decompiler.getId().equals("enigma:cfr") ? "Abstract" : "abstract") // cfr capitalizes the class for some reason
 		);
 
 		// field references
 		if (!decompiler.getId().equals("enigma:cfr")) {
 			// cfr doesn't decompile the field assign inside the constructor
 			assertThat(
-				checker.getReferenceTokens(new EntryReference<>(
-					TestEntryFactory.newField("a$abstract", "transient", "C"),
-					"",
-					TestEntryFactory.newMethod("a$abstract", "<init>", "(La;)V")
-				)),
-				contains("transient")
+					checker.getReferenceTokens(new EntryReference<>(
+						TestEntryFactory.newField("a$abstract", "transient", "C"),
+						"",
+						TestEntryFactory.newMethod("a$abstract", "<init>", "(La;)V")
+					)),
+					contains("transient")
 			);
 		}
+
 		if (!decompiler.getId().equals("enigma:vineflower")) {
 			// due to an oversight, there's no way to know where a method starts and ends when using vineflower
 			// so any references after the throws() declaration are linked to said method instead of the correct one, class()
 			assertThat(
-				checker.getReferenceTokens(new EntryReference<>(
-					TestEntryFactory.newField("a$abstract", "transient", "C"),
-					"",
-					TestEntryFactory.newMethod("a", "class", "()V")
-				)),
-				contains("transient")
+					checker.getReferenceTokens(new EntryReference<>(
+						TestEntryFactory.newField("a$abstract", "transient", "C"),
+						"",
+						TestEntryFactory.newMethod("a", "class", "()V")
+					)),
+					contains("transient")
 			);
 		}
 
 		// method references
 		assertThat(
-			checker.getReferenceTokens(new EntryReference<>(
-				TestEntryFactory.newMethod("a", "new", "()V"),
-				"",
-				TestEntryFactory.newMethod("a", "try", "()V")
-			)),
-			contains("new")
+				checker.getReferenceTokens(new EntryReference<>(
+					TestEntryFactory.newMethod("a", "new", "()V"),
+					"",
+					TestEntryFactory.newMethod("a", "try", "()V")
+				)),
+				contains("new")
 		);
 		if (!decompiler.getId().equals("enigma:vineflower")) {
 			assertThat(
-				checker.getReferenceTokens(new EntryReference<>(
-					TestEntryFactory.newMethod("a$abstract", "throws", "()V"),
-					"",
-					TestEntryFactory.newMethod("a", "class", "()V")
-				)),
-				contains("throws")
+					checker.getReferenceTokens(new EntryReference<>(
+						TestEntryFactory.newMethod("a$abstract", "throws", "()V"),
+						"",
+						TestEntryFactory.newMethod("a", "class", "()V")
+					)),
+					contains("throws")
 			);
 		}
 
 		// class references
 		if (!decompiler.getId().equals("enigma:cfr")) {
 			assertThat(
-				checker.getReferenceTokens(new EntryReference<>(
-					TestEntryFactory.newClass("a$interface"),
-					"",
-					decompiler.getId().equals("enigma:procyon") ? TestEntryFactory.newClass("a$abstract") : TestEntryFactory.newMethod("a", "class", "()V")
-				)),
-				contains("interface")
+					checker.getReferenceTokens(new EntryReference<>(
+						TestEntryFactory.newClass("a$interface"),
+						"",
+						decompiler.getId().equals("enigma:procyon") ? TestEntryFactory.newClass("a$abstract") : TestEntryFactory.newMethod("a", "class", "()V")
+					)),
+					contains("interface")
 			);
 		}
+
 		if (!decompiler.getId().equals("enigma:vineflower")) {
 			assertThat(
-				checker.getReferenceTokens(new EntryReference<>(
-					TestEntryFactory.newClass("a$abstract"),
-					"",
-					TestEntryFactory.newMethod("a", "class", "()V")
-				)),
-				hasItem(decompiler.getId().equals("enigma:cfr") ? "Abstract" : "abstract")
+					checker.getReferenceTokens(new EntryReference<>(
+						TestEntryFactory.newClass("a$abstract"),
+						"",
+						TestEntryFactory.newMethod("a", "class", "()V")
+					)),
+					hasItem(decompiler.getId().equals("enigma:cfr") ? "Abstract" : "abstract")
 			);
 		}
 	}

--- a/enigma/src/test/java/org/quiltmc/enigma/DecompilationTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/DecompilationTest.java
@@ -37,9 +37,15 @@ public class DecompilationTest {
 
 	@ParameterizedTest
 	@MethodSource("provideDecompilers")
+	public void testInvalidIdentifiers(DecompilerService decompiler) {
+		// todo
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideDecompilers")
 	public void testVarargsDecompile(DecompilerService decompiler) {
 		TokenChecker checker = this.getTokenChecker(decompiler);
-		MethodEntry method = TestEntryFactory.newMethod("a", "a", "()V");
+		MethodEntry method = TestEntryFactory.newMethod("b", "a", "()V");
 		assertThat(checker.getReferenceTokens(
 				new EntryReference<>(TestEntryFactory.newMethod("org/quiltmc/enigma/input/Keep", "a", "([Ljava/lang/String;)V"), "", method)
 		), contains("a"));

--- a/enigma/src/test/java/org/quiltmc/enigma/DecompilationTest.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/DecompilationTest.java
@@ -6,12 +6,14 @@ import org.quiltmc.enigma.api.class_provider.ClassProvider;
 import org.quiltmc.enigma.api.class_provider.JarClassProvider;
 import org.quiltmc.enigma.api.service.DecompilerService;
 import org.quiltmc.enigma.api.source.Decompilers;
+import org.quiltmc.enigma.api.translation.representation.TypeDescriptor;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -38,7 +40,144 @@ public class DecompilationTest {
 	@ParameterizedTest
 	@MethodSource("provideDecompilers")
 	public void testInvalidIdentifiers(DecompilerService decompiler) {
-		// todo
+		TokenChecker checker = this.getTokenChecker(decompiler);
+
+		// field declarations
+		for (TypeDescriptor.Primitive type : TypeDescriptor.Primitive.values()) {
+			assertThat(
+				checker.getDeclarationToken(TestEntryFactory.newField("a", type.getKeyword(), "" + type.getCode())),
+				equalTo(type.getKeyword())
+			);
+		}
+
+		List<String> fieldNames = List.of("final", "break", "for", "static", "super", "private", "import", "synchronized", "$");
+		for (String name : fieldNames) {
+			assertThat(
+				checker.getDeclarationToken(TestEntryFactory.newField("a", name, "I")),
+				equalTo(name)
+			);
+		}
+
+		assertThat(
+			checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "transient", "C")),
+			equalTo("transient")
+		);
+		assertThat(
+			checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "volatile", "Z")),
+			equalTo("volatile")
+		);
+		assertThat(
+			checker.getDeclarationToken(TestEntryFactory.newField("a$abstract", "false", "Z")),
+			equalTo("false")
+		);
+
+		// method declarations
+		List<String> methodNames = List.of("new", "assert", "try", "switch", "void", "throws", "class", "while");
+		for (String name : methodNames) {
+			assertThat(
+				checker.getDeclarationToken(TestEntryFactory.newMethod("a", name, "()V")),
+				equalTo(name)
+			);
+		}
+
+		assertThat(
+			checker.getDeclarationToken(TestEntryFactory.newMethod("a", "native", "()I")),
+			equalTo("native")
+		);
+		if (!decompiler.getId().equals("enigma:cfr")) {
+			// cfr doesnt decompile the local interface, just the local class
+			assertThat(
+				checker.getDeclarationToken(TestEntryFactory.newMethod("a$interface", "throws", "()V")),
+				equalTo("throws")
+			);
+			assertThat(
+				checker.getDeclarationToken(TestEntryFactory.newMethod("a$interface", "enum", "()I")),
+				equalTo("enum")
+			);
+		}
+
+		// class declarations
+		assertThat(
+			checker.getDeclarationToken(TestEntryFactory.newClass("a$enum")),
+			equalTo("enum")
+		);
+		if (!decompiler.getId().equals("enigma:cfr")) {
+			assertThat(
+				checker.getDeclarationToken(TestEntryFactory.newClass("a$interface")),
+				equalTo("interface")
+			);
+		}
+		assertThat(
+			checker.getDeclarationToken(TestEntryFactory.newClass("a$abstract")),
+			equalTo(decompiler.getId().equals("enigma:cfr") ? "Abstract" : "abstract") // cfr capitalizes the class for some reason
+		);
+
+		// field references
+		if (!decompiler.getId().equals("enigma:cfr")) {
+			// cfr doesn't decompile the field assign inside the constructor
+			assertThat(
+				checker.getReferenceTokens(new EntryReference<>(
+					TestEntryFactory.newField("a$abstract", "transient", "C"),
+					"",
+					TestEntryFactory.newMethod("a$abstract", "<init>", "(La;)V")
+				)),
+				contains("transient")
+			);
+		}
+		if (!decompiler.getId().equals("enigma:vineflower")) {
+			// due to an oversight, there's no way to know where a method starts and ends when using vineflower
+			// so any references after the throws() declaration are linked to said method instead of the correct one, class()
+			assertThat(
+				checker.getReferenceTokens(new EntryReference<>(
+					TestEntryFactory.newField("a$abstract", "transient", "C"),
+					"",
+					TestEntryFactory.newMethod("a", "class", "()V")
+				)),
+				contains("transient")
+			);
+		}
+
+		// method references
+		assertThat(
+			checker.getReferenceTokens(new EntryReference<>(
+				TestEntryFactory.newMethod("a", "new", "()V"),
+				"",
+				TestEntryFactory.newMethod("a", "try", "()V")
+			)),
+			contains("new")
+		);
+		if (!decompiler.getId().equals("enigma:vineflower")) {
+			assertThat(
+				checker.getReferenceTokens(new EntryReference<>(
+					TestEntryFactory.newMethod("a$abstract", "throws", "()V"),
+					"",
+					TestEntryFactory.newMethod("a", "class", "()V")
+				)),
+				contains("throws")
+			);
+		}
+
+		// class references
+		if (!decompiler.getId().equals("enigma:cfr")) {
+			assertThat(
+				checker.getReferenceTokens(new EntryReference<>(
+					TestEntryFactory.newClass("a$interface"),
+					"",
+					decompiler.getId().equals("enigma:procyon") ? TestEntryFactory.newClass("a$abstract") : TestEntryFactory.newMethod("a", "class", "()V")
+				)),
+				contains("interface")
+			);
+		}
+		if (!decompiler.getId().equals("enigma:vineflower")) {
+			assertThat(
+				checker.getReferenceTokens(new EntryReference<>(
+					TestEntryFactory.newClass("a$abstract"),
+					"",
+					TestEntryFactory.newMethod("a", "class", "()V")
+				)),
+				hasItem(decompiler.getId().equals("enigma:cfr") ? "Abstract" : "abstract")
+			);
+		}
 	}
 
 	@ParameterizedTest

--- a/enigma/src/test/java/org/quiltmc/enigma/TokenChecker.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TokenChecker.java
@@ -85,7 +85,7 @@ public class TokenChecker {
 			String name = classEntry.getContextualName();
 			Path path = Files.createTempFile("class-" + name.replace("$", "_") + "-", ".html");
 			Files.writeString(path, SourceTestUtil.toHtml(source, name));
-			Logger.info("Debug file created: {}", path.toUri());
+			Logger.info("Debug file created: {} ({})", path.toUri(), this.decompiler.getClass().getCanonicalName());
 		} catch (Exception e) {
 			Logger.error(e, "Failed to create debug source file for {}", classEntry);
 		}

--- a/enigma/src/test/java/org/quiltmc/enigma/TokenChecker.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TokenChecker.java
@@ -45,7 +45,7 @@ public class TokenChecker {
 		// decompile the class
 		Source source = this.decompiler.getUndocumentedSource(entry.getTopLevelClass().getFullName());
 		// DEBUG
-		createDebugFile(source, entry.getTopLevelClass());
+		// this.createDebugFile(source, entry.getTopLevelClass());
 		String string = source.asString();
 		SourceIndex index = source.index();
 
@@ -65,7 +65,7 @@ public class TokenChecker {
 		String string = source.asString();
 		SourceIndex index = source.index();
 		// DEBUG
-		// createDebugFile(source, reference.context.getTopLevelClass());
+		// this.createDebugFile(source, reference.context.getTopLevelClass());
 
 		// get the token values
 		List<String> values = new ArrayList<>();

--- a/enigma/src/test/java/org/quiltmc/enigma/TokenChecker.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TokenChecker.java
@@ -43,9 +43,9 @@ public class TokenChecker {
 
 	protected String getDeclarationToken(Entry<?> entry) {
 		// decompile the class
-		Source source = this.decompiler.getUndocumentedSource(entry.getContainingClass().getFullName());
+		Source source = this.decompiler.getUndocumentedSource(entry.getTopLevelClass().getFullName());
 		// DEBUG
-		// createDebugFile(source, entry.getContainingClass());
+		createDebugFile(source, entry.getTopLevelClass());
 		String string = source.asString();
 		SourceIndex index = source.index();
 
@@ -61,11 +61,11 @@ public class TokenChecker {
 	@SuppressWarnings("unchecked")
 	protected Collection<String> getReferenceTokens(EntryReference<? extends Entry<?>, ? extends Entry<?>> reference) {
 		// decompile the class
-		Source source = this.decompiler.getUndocumentedSource(reference.context.getContainingClass().getFullName());
+		Source source = this.decompiler.getUndocumentedSource(reference.context.getTopLevelClass().getFullName());
 		String string = source.asString();
 		SourceIndex index = source.index();
 		// DEBUG
-		// createDebugFile(source, reference.context.getContainingClass());
+		// createDebugFile(source, reference.context.getTopLevelClass());
 
 		// get the token values
 		List<String> values = new ArrayList<>();

--- a/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/Keep.java
@@ -1,6 +1,7 @@
 package org.quiltmc.enigma.input;
 
 public class Keep {
+	// a([Ljava/lang/String;)V
 	public static void main(String... args) {
 		System.out.println("Keep me!");
 	}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestInvalidIdentifiers.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestInvalidIdentifiers.java
@@ -1,0 +1,154 @@
+package org.quiltmc.enigma.input.decompiler;
+
+import java.util.Random;
+
+// a
+public class TestInvalidIdentifiers {
+	// byte
+	byte f1;
+	// boolean
+	boolean f2;
+	// int
+	int f3;
+	// float
+	float f4;
+	// double
+	double f5;
+	// short
+	short f6;
+	// char
+	char f7;
+	// long
+	long f8;
+	// final
+	int f9;
+	// break
+	int f10;
+	// for
+	int f11;
+	// static
+	int f12;
+	// super
+	int f13;
+	// private
+	int f14;
+	// import
+	int f15;
+	// synchronized
+	int f16;
+	// $
+	int f17;
+
+	// new()V
+	public void invokeConstructor() {
+		System.out.println(new TestInvalidIdentifiers());
+	}
+
+	// assert()V
+	public void assertStatement() {
+		Random r = new Random();
+		assert r.nextBoolean();
+	}
+
+	// try()V
+	public void tryCatchThrownException() {
+		try {
+			throw new RuntimeException("meow :3");
+		} catch (RuntimeException e) {
+			e.printStackTrace();
+		}
+	}
+
+	// switch()V
+	public void switchCase() {
+		int k = new Random().nextInt(3);
+		switch (k) {
+			case 0 -> System.out.println(1);
+			case 1 -> {
+				int j = k << (3 * new Random().nextInt(3));
+				System.out.println(j);
+			}
+			case 2 -> System.out.println(-1);
+		}
+	}
+
+	// void()V
+	public void noop() {
+	}
+
+	// throws()V
+	public void throwException() throws IllegalStateException {
+		String s = "not meow :(";
+		throw new IllegalStateException(s);
+	}
+
+	// class()V
+	public void innerClass() {
+		// interface
+		interface Interface {
+			// throws()V
+			void meow();
+
+			// enum()I
+			default int purr() {
+				return 1;
+			}
+		}
+
+		// abstract
+		abstract class Abstract implements Interface {
+			// transient
+			private char m;
+			// volatile
+			private boolean b = false;
+			// false
+			private boolean c = true;
+
+			public Abstract() {
+				this.m = 'o';
+			}
+
+			public void meow() {
+				System.out.println("meow");
+			}
+		}
+
+		Abstract c = new Abstract() {};
+		c.meow();
+		System.out.println(c.m);
+	}
+
+	// while()V
+	public static void loop() {
+		int i = 0;
+		boolean b = true;
+		do {
+			for (int j = 0; j < 5; j++) {
+				System.out.println(j);
+			}
+
+			if (++i > 3) {
+				break;
+			}
+
+			for (int j = 5; j > 0; j--) {
+				System.out.println(j);
+			}
+		} while (b);
+	}
+
+	// native()I
+	private static int n() {
+		return -1;
+	}
+
+	enum Enum {
+		Foo;
+
+		final Enum e;
+
+		Enum() {
+			this.e = this;
+		}
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestInvalidIdentifiers.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestInvalidIdentifiers.java
@@ -55,7 +55,7 @@ public class TestInvalidIdentifiers {
 		try {
 			throw new RuntimeException("meow :3");
 		} catch (RuntimeException e) {
-			e.printStackTrace();
+			invokeConstructor();
 		}
 	}
 
@@ -104,7 +104,7 @@ public class TestInvalidIdentifiers {
 			// false
 			private boolean c = true;
 
-			public Abstract() {
+			Abstract() {
 				this.m = 'o';
 			}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestInvalidIdentifiers.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestInvalidIdentifiers.java
@@ -55,7 +55,7 @@ public class TestInvalidIdentifiers {
 		try {
 			throw new RuntimeException("meow :3");
 		} catch (RuntimeException e) {
-			invokeConstructor();
+			this.invokeConstructor();
 		}
 	}
 

--- a/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestVarargsDecompile.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/decompiler/TestVarargsDecompile.java
@@ -2,7 +2,9 @@ package org.quiltmc.enigma.input.decompiler;
 
 import org.quiltmc.enigma.input.Keep;
 
+// b
 public class TestVarargsDecompile {
+	// a()V
 	public void useVarargs() {
 		Keep.main("Lorem", "ipsum");
 	}

--- a/enigma/src/test/resources/mappings-decompiler.txt
+++ b/enigma/src/test/resources/mappings-decompiler.txt
@@ -1,0 +1,57 @@
+org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers -> a:
+# {"fileName":"TestInvalidIdentifiers.java","id":"sourceFile"}
+    byte f1 -> byte
+    boolean f2 -> boolean
+    int f3 -> int
+    float f4 -> float
+    double f5 -> double
+    short f6 -> short
+    char f7 -> char
+    long f8 -> long
+    int f9 -> final
+    int f10 -> break
+    int f11 -> for
+    int f12 -> static
+    int f13 -> super
+    int f14 -> private
+    int f15 -> import
+    int f16 -> synchronized
+    int f17 -> $
+    boolean $assertionsDisabled -> b
+    6:6:void <init>() -> <init>
+    44:45:void invokeConstructor() -> new
+    49:51:void assertStatement() -> assert
+    56:60:void tryCatchThrownException() -> try
+    64:73:void switchCase() -> switch
+    77:77:void noop() -> void
+    81:82:void throwException() -> throws
+    116:119:void innerClass() -> class
+    123:138:void loop() -> while
+    142:142:int n() -> native
+    6:6:void <clinit>() -> <clinit>
+org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$1 -> a$1:
+# {"fileName":"TestInvalidIdentifiers.java","id":"sourceFile"}
+    org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers this$0 -> a
+    116:116:void <init>(org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers) -> <init>
+org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$1Abstract -> a$abstract:
+# {"fileName":"TestInvalidIdentifiers.java","id":"sourceFile"}
+    char m -> transient
+    boolean b -> volatile
+    boolean c -> false
+    org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers this$0 -> b
+    103:109:void <init>(org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers) -> <init>
+    112:113:void meow() -> throws
+org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$1Interface -> a$interface:
+# {"fileName":"TestInvalidIdentifiers.java","id":"sourceFile"}
+    void meow() -> throws
+    94:94:int purr() -> enum
+org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$Enum -> a$enum:
+# {"fileName":"TestInvalidIdentifiers.java","id":"sourceFile"}
+    org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$Enum Foo -> final
+    org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$Enum e -> this
+    org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$Enum[] $VALUES -> a
+    145:145:org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$Enum[] values() -> a
+    145:145:org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$Enum valueOf(java.lang.String) -> a
+    150:152:void <init>(java.lang.String,int) -> <init>
+    145:145:org.quiltmc.enigma.input.decompiler.TestInvalidIdentifiers$Enum[] $values() -> b
+    145:146:void <clinit>() -> <clinit>

--- a/enigma/src/test/resources/proguard-decompiler-test.conf
+++ b/enigma/src/test/resources/proguard-decompiler-test.conf
@@ -1,0 +1,9 @@
+-overloadaggressively
+-repackageclasses
+-allowaccessmodification
+-dontoptimize
+-dontshrink
+-keepparameternames
+-keepattributes
+-applymapping mappings-decompiler.txt
+-keep class org.quiltmc.enigma.input.Keep


### PR DESCRIPTION
Fixes #249. Im not quite sure why, but both cfr and vineflower would ignore methods named "new" while generating tokens for the decompiled source; removing said behavior didn't have any side effects as far as i can tell

tests still needed

Also, debug tokens didn't work, so i fixed those too