### PR TITLE
Fix navigator keybind focus issues

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorTabbedPane.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorTabbedPane.java
@@ -75,8 +75,10 @@ public class EditorTabbedPane {
 					this.closeEditor(ed);
 				} else if (KeyBinds.ENTRY_NAVIGATOR_NEXT.matches(keyEvent)) {
 					this.navigator.navigateDown();
+					keyEvent.consume();
 				} else if (KeyBinds.ENTRY_NAVIGATOR_LAST.matches(keyEvent)) {
 					this.navigator.navigateUp();
+					keyEvent.consume();
 				}
 			}));
 


### PR DESCRIPTION
Using Ctrl + Up Arrow to navigate up on the navigator would previously shift focus away from the editor panel and prevent you from mapping or navigating until you manually refocused it. This PR fixes this issue.