### PR TITLE
Navigator rework

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
@@ -76,14 +76,14 @@ public class NavigatorPanel extends JPanel {
 	 * Navigates to the next entry matching the current filter.
 	 */
 	public void navigateDown() {
-		tryNavigate(false);
+		this.tryNavigate(false);
 	}
 
 	/**
 	 * Navigates to the last entry matching the current filter.
 	 */
 	public void navigateUp() {
-		tryNavigate(true);
+		this.tryNavigate(true);
 	}
 
 	private void onTypeChange() {
@@ -110,7 +110,7 @@ public class NavigatorPanel extends JPanel {
 			Entry<?> entry = this.getClosestEntryToCursor(currentEntrySet, reverse);
 			this.gui.getController().navigateTo(entry);
 			this.currentIndex = currentEntrySet.indexOf(entry);
-			updateStatsLabel();
+			this.updateStatsLabel();
 		}
 	}
 
@@ -127,6 +127,7 @@ public class NavigatorPanel extends JPanel {
 				}
 			}
 		}
+		
 		return possibleEntriesCopy.get(0);
 	}
 

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
@@ -116,7 +116,10 @@ public class NavigatorPanel extends JPanel {
 
 	public Entry<?> getClosestEntryToCursor(List<Entry<?>> currentEntrySet, boolean reverse) {
 		List<Entry<?>> possibleEntriesCopy = new ArrayList<>(currentEntrySet);
-		if (reverse) Collections.reverse(possibleEntriesCopy);
+		if (reverse) {
+			Collections.reverse(possibleEntriesCopy);
+		}
+		
 		int cursorPos = this.gui.getActiveEditor().getEditor().getCaretPosition();
 		for (Entry<?> entry : possibleEntriesCopy) {
 			List<Token> tokens = this.gui.getController().getTokensForReference(this.gui.getActiveEditor().getSource(), EntryReference.declaration(entry, entry.getName()));

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
@@ -127,7 +127,7 @@ public class NavigatorPanel extends JPanel {
 				}
 			}
 		}
-		
+
 		return possibleEntriesCopy.get(0);
 	}
 

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
@@ -119,7 +119,7 @@ public class NavigatorPanel extends JPanel {
 		if (reverse) {
 			Collections.reverse(possibleEntriesCopy);
 		}
-		
+
 		int cursorPos = this.gui.getActiveEditor().getEditor().getCaretPosition();
 		for (Entry<?> entry : possibleEntriesCopy) {
 			List<Token> tokens = this.gui.getController().getTokensForReference(this.gui.getActiveEditor().getSource(), EntryReference.declaration(entry, entry.getName()));

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/NavigatorPanel.java
@@ -17,7 +17,11 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import java.awt.Color;
 import java.awt.event.ItemEvent;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A panel with buttons to navigate to the next and previous items in its entry collection.


### PR DESCRIPTION
Implements the navigator rework as described in #267. 

- Navigation is now always relative to the cursor rather than maintaining a separate stored position.
- The navigator still wraps around when necessary.
- The navigator's index is still stored but is now only used for display purposes. It is updated accordingly when navigating.