### PR TITLE
fix navigating on click when clicking to exit quick find

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
@@ -174,6 +174,7 @@ public class EditorPanel {
 					}
 				} else if (KeyBinds.EDITOR_QUICK_FIND.matches(event)) {
 					// prevent navigating on click when quick find activated
+					EditorPanel.this.shouldNavigateOnClick = false; // CTRL
 				} else if (KeyBinds.EDITOR_ZOOM_IN.matches(event)) {
 					EditorPanel.this.offsetEditorZoom(2);
 				} else if (KeyBinds.EDITOR_ZOOM_OUT.matches(event)) {


### PR DESCRIPTION
Fixes a bug where if you press `ctrl+f` to quick-find, `shouldNavigateOnClick` remains `true` from when you held `ctrl`.

This means that you navigate to any token you click on after opening quick-find, even if not holding control.