### PR TITLE
Named command args

### DIFF
--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/ArgsParser.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/ArgsParser.java
@@ -1,0 +1,204 @@
+package org.quiltmc.enigma.command;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableIterator;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+final class ArgsParser<P> implements Iterable<Argument<?>> {
+	static <T> ArgsParser<T> of(Argument<T> arg) {
+		return new ArgsParser<>(ImmutableList.of(arg), (values, from) -> from.parse(arg, values));
+	}
+
+	static <T1, T2, P> ArgsParser<P> of(Argument<T1> arg1, Argument<T2> arg2, BiFunction<T1, T2, P> packer) {
+		return new ArgsParser<>(ImmutableList.of(arg1, arg2), (values, from) -> packer.apply(
+			from.parse(arg1, values), from.parse(arg2, values)
+		));
+	}
+
+	static <T1, T2, T3, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3,
+			Packer3<T1, T2, T3, P> packer
+	) {
+		return new ArgsParser<>(ImmutableList.of(arg1, arg2, arg3), (values, from) -> packer.pack(
+			from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values)
+		));
+	}
+
+	static <T1, T2, T3, T4, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3, Argument<T4> arg4,
+			Packer4<T1, T2, T3, T4, P> packer
+	) {
+		return new ArgsParser<>(ImmutableList.of(arg1, arg2, arg3, arg4), (values, from) -> packer.pack(
+			from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values), from.parse(arg4, values)
+		));
+	}
+
+	static <T1, T2, T3, T4, T5, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3, Argument<T4> arg4, Argument<T5> arg5,
+			Packer5<T1, T2, T3, T4, T5, P> packer
+	) {
+		return new ArgsParser<>(ImmutableList.of(arg1, arg2, arg3, arg4, arg5), (values, from) -> packer.pack(
+			from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values),
+			from.parse(arg4, values), from.parse(arg5, values)
+		));
+	}
+
+	static <T1, T2, T3, T4, T5, T6, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3,
+			Argument<T4> arg4, Argument<T5> arg5, Argument<T6> arg6,
+			Packer6<T1, T2, T3, T4, T5, T6, P> packer
+	) {
+		return new ArgsParser<>(ImmutableList.of(arg1, arg2, arg3, arg4, arg5, arg6), (values, from) -> packer.pack(
+			from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values),
+			from.parse(arg4, values), from.parse(arg5, values), from.parse(arg6, values)
+		));
+	}
+
+	static <T1, T2, T3, T4, T5, T6, T7, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3, Argument<T4> arg4,
+			Argument<T5> arg5, Argument<T6> arg6, Argument<T7> arg7,
+			Packer7<T1, T2, T3, T4, T5, T6, T7, P> packer
+	) {
+		return new ArgsParser<>(
+				ImmutableList.of(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+				(values, from) -> packer.pack(
+					from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values),
+					from.parse(arg4, values), from.parse(arg5, values), from.parse(arg6, values),
+					from.parse(arg7, values)
+				)
+		);
+	}
+
+	static <T1, T2, T3, T4, T5, T6, T7, T8, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3, Argument<T4> arg4,
+			Argument<T5> arg5, Argument<T6> arg6, Argument<T7> arg7, Argument<T8> arg8,
+			Packer8<T1, T2, T3, T4, T5, T6, T7, T8, P> packer
+	) {
+		return new ArgsParser<>(
+				ImmutableList.of(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+				(values, from) -> packer.pack(
+					from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values),
+					from.parse(arg4, values), from.parse(arg5, values), from.parse(arg6, values),
+					from.parse(arg7, values), from.parse(arg8, values)
+				)
+		);
+	}
+
+	static <T1, T2, T3, T4, T5, T6, T7, T8, T9, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3, Argument<T4> arg4, Argument<T5> arg5,
+			Argument<T6> arg6, Argument<T7> arg7, Argument<T8> arg8, Argument<T9> arg9,
+			Packer9<T1, T2, T3, T4, T5, T6, T7, T8, T9, P> packer
+	) {
+		return new ArgsParser<>(
+				ImmutableList.of(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+				(values, from) -> packer.pack(
+					from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values),
+					from.parse(arg4, values), from.parse(arg5, values), from.parse(arg6, values),
+					from.parse(arg7, values), from.parse(arg8, values), from.parse(arg9, values)
+				)
+		);
+	}
+
+	static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P> ArgsParser<P> of(
+			Argument<T1> arg1, Argument<T2> arg2, Argument<T3> arg3, Argument<T4> arg4, Argument<T5> arg5,
+			Argument<T6> arg6, Argument<T7> arg7, Argument<T8> arg8, Argument<T9> arg9, Argument<T10> arg10,
+			Packer10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P> packer
+	) {
+		return new ArgsParser<>(
+				ImmutableList.of(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10),
+				(values, from) -> packer.pack(
+					from.parse(arg1, values), from.parse(arg2, values), from.parse(arg3, values),
+					from.parse(arg4, values), from.parse(arg5, values), from.parse(arg6, values),
+					from.parse(arg7, values), from.parse(arg8, values), from.parse(arg9, values),
+					from.parse(arg10, values)
+				)
+		);
+	}
+
+	private final ImmutableList<Argument<?>> args;
+
+	private final BiFunction<Map<String, String>, ArgParser, P> impl;
+
+	private ArgsParser(ImmutableList<Argument<?>> args, BiFunction<Map<String, String>, ArgParser, P> impl) {
+		this.args = args;
+		this.impl = impl;
+	}
+
+	P parse(Map<String, String> values, ArgParser from) {
+		return this.impl.apply(values, from);
+	}
+
+	Argument<?> get(int index) {
+		return this.args.get(index);
+	}
+
+	int count() {
+		return this.args.size();
+	}
+
+	boolean isEmpty() {
+		return this.args.isEmpty();
+	}
+
+	@Override
+	@Nonnull
+	public UnmodifiableIterator<Argument<?>> iterator() {
+		return this.args.iterator();
+	}
+
+	@FunctionalInterface
+	interface ArgParser {
+		<T> T parse(Argument<T> arg, Map<String, String> values);
+	}
+
+	@FunctionalInterface
+	interface Packer3<T1, T2, T3, P> {
+		P pack(T1 v1, T2 v2, T3 v3);
+	}
+
+	@FunctionalInterface
+	interface Packer4<T1, T2, T3, T4, P> {
+		P pack(T1 v1, T2 v2, T3 v3, T4 v4);
+	}
+
+	@FunctionalInterface
+	interface Packer5<T1, T2, T3, T4, T5, P> {
+		P pack(T1 v1, T2 v2, T3 v3, T4 v4, T5 v5);
+	}
+
+	@FunctionalInterface
+	interface Packer6<T1, T2, T3, T4, T5, T6, P> {
+		P pack(T1 v1, T2 v2, T3 v3, T4 v4, T5 v5, T6 v6);
+	}
+
+	@FunctionalInterface
+	interface Packer7<T1, T2, T3, T4, T5, T6, T7, P> {
+		P pack(T1 v1, T2 v2, T3 v3, T4 v4, T5 v5, T6 v6, T7 v7);
+	}
+
+	@FunctionalInterface
+	interface Packer8<T1, T2, T3, T4, T5, T6, T7, T8, P> {
+		P pack(T1 v1, T2 v2, T3 v3, T4 v4, T5 v5, T6 v6, T7 v7, T8 v8);
+	}
+
+	@FunctionalInterface
+	interface Packer9<T1, T2, T3, T4, T5, T6, T7, T8, T9, P> {
+		P pack(T1 v1, T2 v2, T3 v3, T4 v4, T5 v5, T6 v6, T7 v7, T8 v8, T9 v9);
+	}
+
+	@FunctionalInterface
+	interface Packer10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, P> {
+		P pack(T1 v1, T2 v2, T3 v3, T4 v4, T5 v5, T6 v6, T7 v7, T8 v8, T9 v9, T10 v10);
+	}
+
+	static final class Empty {
+		static final Empty INSTANCE = new Empty();
+
+		static final ArgsParser<Empty> PARSER = new ArgsParser<>(ImmutableList.of(), (values, from) -> INSTANCE);
+
+		private Empty() { }
+	}
+}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/ArgsParser.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/ArgsParser.java
@@ -6,6 +6,7 @@ import com.google.common.collect.UnmodifiableIterator;
 import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 final class ArgsParser<P> implements Iterable<Argument<?>> {
 	static <T> ArgsParser<T> of(Argument<T> arg) {
@@ -147,6 +148,10 @@ final class ArgsParser<P> implements Iterable<Argument<?>> {
 	@Nonnull
 	public UnmodifiableIterator<Argument<?>> iterator() {
 		return this.args.iterator();
+	}
+
+	Stream<Argument<?>> stream() {
+		return this.args.stream();
 	}
 
 	@FunctionalInterface

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -1,5 +1,7 @@
 package org.quiltmc.enigma.command;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,7 +26,9 @@ import java.util.stream.Collectors;
  * @param <T> the type of the argument
  */
 final class Argument<T> {
+	@VisibleForTesting
 	static final char SEPARATOR = ' ';
+	@VisibleForTesting
 	static final char NAME_DELIM = '=';
 
 	static final String ALTERNATIVES_DELIM = "|";

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -134,6 +134,7 @@ final class Argument<T> {
 
 	static Optional<Path> getPath(String path) {
 		return Optional.ofNullable(path)
+			.filter(string -> !string.isEmpty())
 			.map(Paths::get)
 			.map(Path::toAbsolutePath);
 	}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -1,5 +1,6 @@
 package org.quiltmc.enigma.command;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -167,7 +168,17 @@ final class Argument<T> {
 		return this.displayForm;
 	}
 
-	T get(Map<String, String> args) {
+	@Nullable
+	T from(Map<String, String> args) {
 		return this.fromString.apply(args.get(this.name));
+	}
+
+	T requireFrom(Map<String, String> values) {
+		final T t = this.from(values);
+		if (t == null) {
+			throw new IllegalArgumentException(this.name + " is required");
+		}
+
+		return t;
 	}
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -1,57 +1,156 @@
 package org.quiltmc.enigma.command;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-final class Argument {
+final class Argument<T> {
 	static final char SEPARATOR = ' ';
 	static final char NAME_DELIM = '=';
 
-	private static final String ALTERNATIVES_DELIM = "|";
-	private static final String PATH_TYPE = "path";
-	private static final String BOOL_TYPE = true + ALTERNATIVES_DELIM + false;
+	static final String ALTERNATIVES_DELIM = "|";
+	static final String BOOL_TYPE = true + ALTERNATIVES_DELIM + false;
+	static final String PATH_TYPE = "path";
 
-	/**
-	 * @return an argument whose {@code typeDescription} is {@value #PATH_TYPE}
-	 */
-	static Argument ofPath(String name, String explanation) {
-		return new Argument(name, PATH_TYPE, explanation);
+	static Argument<Path> ofReadablePath(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getReadablePath, explanation);
+	}
+
+	static Argument<Path> ofReadableFile(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getReadableFile, explanation);
+	}
+
+	static Argument<Path> ofReadableFolder(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getReadableFolder, explanation);
+	}
+
+	static Argument<Path> ofWritablePath(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getWritablePath, explanation);
+	}
+
+	static Argument<Path> ofWritableFile(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getWritableFile, explanation);
+	}
+
+	static Argument<Path> ofWritableFolder(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getWritableFolder, explanation);
 	}
 
 	/**
-	 * @return an argument whose {@code typeDescription} lists its allowed values
+	 * Creates a string argument whose {@code typeDescription} lists its allowed values.
 	 */
-	static Argument ofEnum(String name, Class<? extends Enum<?>> type, String explanation) {
+	static Argument<String> ofLenientEnum(String name, Class<? extends Enum<?>> type, String explanation) {
 		final String alternatives = Arrays.stream(type.getEnumConstants())
 				.map(Object::toString)
 				.collect(Collectors.joining(ALTERNATIVES_DELIM));
-		return new Argument(name, alternatives, explanation);
+		return ofString(name, alternatives, explanation);
 	}
 
-	/**
-	 * @return an argument whose {@code typeDescription} is {@value #BOOL_TYPE}
-	 */
-	static Argument ofBool(String name, String explanation) {
-		return new Argument(name, BOOL_TYPE, explanation);
+	static Argument<Boolean> ofBool(String name, String explanation) {
+		return new Argument<>(name, BOOL_TYPE, Boolean::parseBoolean, explanation);
+	}
+
+	static Argument<String> ofString(String name, String typeDescription, String explanation) {
+		return new Argument<>(name, typeDescription, Function.identity(), explanation);
 	}
 
 	private final String name;
-	private final String explanation;
+	private final Function<String, T> fromString;
 	private final String displayForm;
+	private final String explanation;
 
 	/**
-	 * @param name the name of the argument; may not contain any space or {@value #NAME_DELIM} characters
-	 * @param typeDescription a short description of the type of value to expect; by convention these are in kebab-case,
-	 * 							except for enums which should use {@link #ofEnum(String, Class, String)}
-	 * @param explanation an extended explanation of what the argument accepts and what it's for
+	 * Creates an argument.
 	 *
-	 * @see #ofPath(String, String)
-	 * @see #ofEnum(String, Class, String)
+	 * <p> See static factory methods for common argument types.
+	 *
+	 * @param name the name of the argument; may not contain any space or {@value #NAME_DELIM} characters
+	 * @param typeDescription a short description of the type of value to expect; by convention these are in kebab-case
+	 * 							except for {@link #ofLenientEnum(String, Class, String) enums} and
+	 * 							{@link #ofBool(String, String) booleans}
+	 * @param explanation an extended explanation of what the argument accepts and what it's for
 	 */
-	Argument(String name, String typeDescription, String explanation) {
+	Argument(String name, String typeDescription, Function<String, T> fromString, String explanation) {
 		this.name = name;
-		this.explanation = explanation;
 		this.displayForm = "[" + this.name + NAME_DELIM + "]" + "<" + typeDescription + ">";
+		this.fromString = fromString;
+		this.explanation = explanation;
+	}
+
+	static Path getReadablePath(String path) {
+		return getExistentPath(path).orElse(null);
+	}
+
+	static Path getReadableFile(String path) {
+		return verify(getExistentPath(path), Files::isRegularFile, "Not a file: ").orElse(null);
+	}
+
+	static Path getReadableFolder(String path) {
+		return getExistentFolder(path).orElse(null);
+	}
+
+	static Path getWritablePath(String path) {
+		return getParentedPath(path).orElse(null);
+	}
+
+	static Path getWritableFile(String path) {
+		return verify(getParentedPath(path), p -> !Files.isDirectory(p), "Not a file: ").orElse(null);
+	}
+
+	static Path getWritableFolder(String path) {
+		return getExistentFolder(path).orElse(null);
+	}
+
+	static Optional<Path> getExistentFolder(String path) {
+		return verify(getExistentPath(path), Files::isDirectory, "Not a folder: ");
+	}
+
+	static Optional<Path> getExistentPath(String path) {
+		return verify(getPath(path), Files::exists, "Cannot find path: ");
+	}
+
+	static Optional<Path> getParentedPath(String path) {
+		return peek(getPath(path), p -> {
+			final Path parent = p.getParent();
+			if (parent == null) {
+				throw new IllegalArgumentException("Cannot write path: " + p);
+			}
+
+			try {
+				Files.createDirectories(p);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
+
+	static Optional<Path> getPath(String path) {
+		return Optional.ofNullable(path)
+			.map(Paths::get)
+			.map(Path::toAbsolutePath);
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	static <T> Optional<T> verify(Optional<T> optional, Predicate<T> verify, String messagePrefix) {
+		return peek(optional, value -> {
+			if (!verify.test(value)) {
+				throw new IllegalArgumentException(messagePrefix + value);
+			}
+		});
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	static <T> Optional<T> peek(Optional<T> optional, Consumer<T> action) {
+		optional.ifPresent(action);
+		return optional;
 	}
 
 	public String getName() {
@@ -64,5 +163,9 @@ final class Argument {
 
 	public String getDisplayForm() {
 		return this.displayForm;
+	}
+
+	T get(Map<String, String> args) {
+		return this.fromString.apply(args.get(this.name));
 	}
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -1,3 +1,68 @@
 package org.quiltmc.enigma.command;
 
-record Argument(String displayForm, String explanation) { }
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+final class Argument {
+	static final char SEPARATOR = ' ';
+	static final char NAME_DELIM = '=';
+
+	private static final String ALTERNATIVES_DELIM = "|";
+	private static final String PATH_TYPE = "path";
+	private static final String BOOL_TYPE = true + ALTERNATIVES_DELIM + false;
+
+	/**
+	 * @return an argument whose {@code typeDescription} is {@value #PATH_TYPE}
+	 */
+	static Argument ofPath(String name, String explanation) {
+		return new Argument(name, PATH_TYPE, explanation);
+	}
+
+	/**
+	 * @return an argument whose {@code typeDescription} lists its allowed values
+	 */
+	static Argument ofEnum(String name, Class<? extends Enum<?>> type, String explanation) {
+		final String alternatives = Arrays.stream(type.getEnumConstants())
+				.map(Object::toString)
+				.collect(Collectors.joining(ALTERNATIVES_DELIM));
+		return new Argument(name, alternatives, explanation);
+	}
+
+	/**
+	 * @return an argument whose {@code typeDescription} is {@value #BOOL_TYPE}
+	 */
+	static Argument ofBool(String name, String explanation) {
+		return new Argument(name, BOOL_TYPE, explanation);
+	}
+
+	private final String name;
+	private final String explanation;
+	private final String displayForm;
+
+	/**
+	 * @param name the name of the argument; may not contain any space or {@value #NAME_DELIM} characters
+	 * @param typeDescription a short description of the type of value to expect; by convention these are in kebab-case,
+	 * 							except for enums which should use {@link #ofEnum(String, Class, String)}
+	 * @param explanation an extended explanation of what the argument accepts and what it's for
+	 *
+	 * @see #ofPath(String, String)
+	 * @see #ofEnum(String, Class, String)
+	 */
+	Argument(String name, String typeDescription, String explanation) {
+		this.name = name;
+		this.explanation = explanation;
+		this.displayForm = "[" + this.name + NAME_DELIM + "]" + "<" + typeDescription + ">";
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getExplanation() {
+		return this.explanation;
+	}
+
+	public String getDisplayForm() {
+		return this.displayForm;
+	}
+}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -13,6 +13,16 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+/**
+ * Represents an argument for a {@link Command}.
+ *
+ * <p> Contains the argument's name and other details, along with the logic to parse it from a string.<br>
+ * If parsing fails in a predictable way, an {@link IllegalArgumentException} should be thrown.
+ * Note that whether an argument is required is decided per-command; argument parsing should <em>not</em> throw
+ * exceptions when the argument is missing. Instead it should return {@code null}.
+ *
+ * @param <T> the type of the argument
+ */
 final class Argument<T> {
 	static final char SEPARATOR = ' ';
 	static final char NAME_DELIM = '=';
@@ -46,7 +56,7 @@ final class Argument<T> {
 	}
 
 	/**
-	 * Creates a string argument whose {@code typeDescription} lists its allowed values.
+	 * Creates a string argument whose {@code typeDescription} lists expected values.
 	 */
 	static Argument<String> ofLenientEnum(String name, Class<? extends Enum<?>> type, String explanation) {
 		final String alternatives = Arrays.stream(type.getEnumConstants())
@@ -74,9 +84,8 @@ final class Argument<T> {
 	 * <p> See static factory methods for common argument types.
 	 *
 	 * @param name the name of the argument; may not contain any space or {@value #NAME_DELIM} characters
-	 * @param typeDescription a short description of the type of value to expect; by convention these are in kebab-case
-	 * 							except for {@link #ofLenientEnum(String, Class, String) enums} and
-	 * 							{@link #ofBool(String, String) booleans}
+	 * @param typeDescription a short description of the type of value to expect; conventional descriptions are in
+	 *                          kebab-case with alternatives separated by {@value ALTERNATIVES_DELIM}
 	 * @param explanation an extended explanation of what the argument accepts and what it's for
 	 */
 	Argument(String name, String typeDescription, Function<String, T> fromString, String explanation) {

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -102,6 +102,7 @@ final class Argument<T> {
 	}
 
 	static Path getWritableFile(String path) {
+		// !directory so it's true for non-existent files
 		return verify(getParentedPath(path), p -> !Files.isDirectory(p), "Not a file: ").orElse(null);
 	}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/CheckMappingsCommand.java
@@ -7,21 +7,26 @@ import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.tinylog.Logger;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 
 public final class CheckMappingsCommand extends Command {
 	public static final CheckMappingsCommand INSTANCE = new CheckMappingsCommand();
 
 	private CheckMappingsCommand() {
-		super(CommonArguments.INPUT_JAR, CommonArguments.INPUT_MAPPINGS);
+		super(INPUT_JAR, INPUT_MAPPINGS);
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
-		Path fileJarIn = getReadableFile(this.getArg(args, 0)).toPath();
-		Path fileMappings = getReadablePath(this.getArg(args, 1));
-		run(fileJarIn, fileMappings);
+	protected void runImpl(Map<String, String> args) throws Exception {
+		run(
+				getReadableFile(args.get(INPUT_JAR.getName())).toPath(),
+				getReadablePath(args.get(INPUT_MAPPINGS.getName()))
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/CheckMappingsCommand.java
@@ -4,26 +4,27 @@ import org.quiltmc.enigma.api.EnigmaProject;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.PackageVisibilityIndex;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+import org.quiltmc.enigma.command.ArgsParser.Empty;
+import org.quiltmc.enigma.command.CheckMappingsCommand.Required;
 import org.tinylog.Logger;
 
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 
-public final class CheckMappingsCommand extends Command {
+public final class CheckMappingsCommand extends Command<Required, Empty> {
 	public static final CheckMappingsCommand INSTANCE = new CheckMappingsCommand();
 
 	private CheckMappingsCommand() {
-		super(INPUT_JAR, INPUT_MAPPINGS);
+		super(ArgsParser.of(INPUT_JAR, INPUT_MAPPINGS, Required::new), Empty.PARSER);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
-		run(INPUT_JAR.get(args), INPUT_MAPPINGS.get(args));
+	void runImpl(Required required, Empty optional) throws Exception {
+		run(required.inputJar, required.inputMappings);
 	}
 
 	@Override
@@ -63,4 +64,6 @@ public final class CheckMappingsCommand extends Command {
 			throw new IllegalStateException("Errors in package visibility detected, see error logged above!");
 		}
 	}
+
+	record Required(Path inputJar, Path inputMappings) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/CheckMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/CheckMappingsCommand.java
@@ -23,10 +23,7 @@ public final class CheckMappingsCommand extends Command {
 
 	@Override
 	protected void runImpl(Map<String, String> args) throws Exception {
-		run(
-				getReadableFile(args.get(INPUT_JAR.getName())).toPath(),
-				getReadablePath(args.get(INPUT_MAPPINGS.getName()))
-		);
+		run(INPUT_JAR.get(args), INPUT_MAPPINGS.get(args));
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -148,16 +148,16 @@ public abstract sealed class Command<R, O> permits
 			throw new ArgumentHelpException(
 				this, "Too few arguments (%s); at least %s %s required.".formatted(
 						args.length,
-						this.requiredArguments.count() == 1 ? "is" : "are",
-						this.requiredArguments.count()
-					)
+						this.requiredArguments.count(),
+						this.requiredArguments.count() == 1 ? "is" : "are"
+				)
 			);
 		} else if (args.length > this.allArgumentNames.size()) {
 			throw new ArgumentHelpException(
 				this, "Too many arguments (%s); at most %s %s allowed.".formatted(
 						args.length,
-						this.allArgumentNames.size() == 1 ? "is" : "are",
-						this.allArgumentNames.size()
+						this.allArgumentNames.size(),
+						this.allArgumentNames.size() == 1 ? "is" : "are"
 				)
 			);
 		}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -1,7 +1,6 @@
 package org.quiltmc.enigma.command;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.EnigmaProfile;
 import org.quiltmc.enigma.api.EnigmaProject;
@@ -25,7 +24,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -35,27 +33,23 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
-public abstract sealed class Command permits
+public abstract sealed class Command<R, O> permits
 		CheckMappingsCommand, ComposeMappingsCommand, ConvertMappingsCommand, DecompileCommand, DeobfuscateCommand,
 		DropInvalidMappingsCommand, FillClassMappingsCommand, HelpCommand, InsertProposedMappingsCommand,
 		InvertMappingsCommand, MapSpecializedMethodsCommand, PrintStatsCommand {
 	private static final int EARLIEST_ARG_DELIM_INDEX = 1;
 
 	@VisibleForTesting
-	final ImmutableList<Argument<?>> requiredArguments;
+	final ArgsParser<R> requiredArguments;
 	@VisibleForTesting
-	final ImmutableList<Argument<?>> optionalArguments;
+	final ArgsParser<O> optionalArguments;
 
 	private final int totalArgumentCount;
 
-	Command(Argument<?>... requiredArguments) {
-		this(ImmutableList.copyOf(requiredArguments), ImmutableList.of());
-	}
-
-	Command(Collection<Argument<?>> requiredArguments, Collection<Argument<?>> optionalArguments) {
-		this.requiredArguments = ImmutableList.copyOf(requiredArguments);
-		this.optionalArguments = ImmutableList.copyOf(optionalArguments);
-		this.totalArgumentCount = this.requiredArguments.size() + this.optionalArguments.size();
+	Command(ArgsParser<R> requiredArguments, ArgsParser<O> optionalArguments) {
+		this.requiredArguments = requiredArguments;
+		this.optionalArguments = optionalArguments;
+		this.totalArgumentCount = this.requiredArguments.count() + this.optionalArguments.count();
 	}
 
 	public String getUsage() {
@@ -71,8 +65,8 @@ public abstract sealed class Command permits
 		return arguments.toString();
 	}
 
-	private static void appendArguments(StringBuilder builder, List<Argument<?>> arguments) {
-		final int argCount = arguments.size();
+	private static void appendArguments(StringBuilder builder, ArgsParser<?> arguments) {
+		final int argCount = arguments.count();
 		final int iLastArg = argCount - 1;
 		for (int i = 0; i < argCount; i++) {
 			builder.append(arguments.get(i).getDisplayForm());
@@ -90,22 +84,22 @@ public abstract sealed class Command permits
 	final void appendHelp(StringBuilder builder) {
 		builder.append("\t\t").append(this.getName()).append(" ").append(this.getUsage()).append("\n");
 
+		int argIndex = 0;
 		if (!this.requiredArguments.isEmpty()) {
 			builder.append("Arguments:").append("\n");
-			int argIndex = 0;
-			for (int j = 0; j < this.requiredArguments.size(); j++) {
+			for (int j = 0; j < this.requiredArguments.count(); j++) {
 				Argument<?> argument = this.requiredArguments.get(j);
 				appendArgHelp(argument, argIndex, builder);
 				argIndex++;
 			}
+		}
 
-			if (!this.optionalArguments.isEmpty()) {
-				builder.append("\n").append("Optional arguments:").append("\n");
-				for (int i = 0; i < this.optionalArguments.size(); i++) {
-					Argument<?> argument = this.optionalArguments.get(i);
-					appendArgHelp(argument, argIndex, builder);
-					argIndex++;
-				}
+		if (!this.optionalArguments.isEmpty()) {
+			builder.append("\n").append("Optional arguments:").append("\n");
+			for (int i = 0; i < this.optionalArguments.count(); i++) {
+				Argument<?> argument = this.optionalArguments.get(i);
+				appendArgHelp(argument, argIndex, builder);
+				argIndex++;
 			}
 		}
 	}
@@ -116,7 +110,7 @@ public abstract sealed class Command permits
 	 * @return {@code true} if the argument count is valid, {@code false} otherwise
 	 */
 	public boolean checkArgumentCount(int length) {
-		return length >= this.requiredArguments.size() && length <= this.totalArgumentCount;
+		return length >= this.requiredArguments.count() && length <= this.totalArgumentCount;
 	}
 
 	/**
@@ -125,17 +119,17 @@ public abstract sealed class Command permits
 	 * @throws Exception on any error
 	 */
 	public final void run(String... args) throws Exception {
-		if (args.length < this.requiredArguments.size()) {
+		if (args.length < this.requiredArguments.count()) {
 			throw new ArgumentHelpException(
-					"Too few arguments (%s); at least %s %s required.".formatted(
+				this, "Too few arguments (%s); at least %s %s required.".formatted(
 						args.length,
-						this.requiredArguments.size() == 1 ? "is" : "are",
-						this.requiredArguments.size()
+						this.requiredArguments.count() == 1 ? "is" : "are",
+						this.requiredArguments.count()
 					)
 			);
 		} else if (args.length > this.totalArgumentCount) {
 			throw new ArgumentHelpException(
-					"Too many arguments (%s); at most %s %s allowed.".formatted(
+				this, "Too many arguments (%s); at most %s %s allowed.".formatted(
 						args.length,
 						this.totalArgumentCount == 1 ? "is" : "are",
 						this.totalArgumentCount
@@ -149,12 +143,14 @@ public abstract sealed class Command permits
 		final BiConsumer<String, Integer> addNamedArg = (rawValue, delim) -> {
 			final String name = rawValue.substring(0, delim);
 			if (positionalArgNames.contains(name)) {
-				throw new ArgumentHelpException("'%s' specified as both positional and named argument.".formatted(name));
+				throw new ArgumentHelpException(
+					this, "'%s' specified as both positional and named argument.".formatted(name)
+				);
 			}
 
 			final String value = rawValue.substring(delim + 1);
 			if (valuesByName.put(name, value) != null) {
-				throw new ArgumentHelpException("'%s' argument named more than once.".formatted(name));
+				throw new ArgumentHelpException(this, "'%s' argument named more than once.".formatted(name));
 			}
 		};
 
@@ -164,9 +160,9 @@ public abstract sealed class Command permits
 			final String rawValue = args[i];
 			final int delim = indexOfNameDelim(rawValue);
 			if (delim < EARLIEST_ARG_DELIM_INDEX) {
-				final Argument<?> arg = i < this.requiredArguments.size()
+				final Argument<?> arg = i < this.requiredArguments.count()
 						? this.requiredArguments.get(i)
-						: this.optionalArguments.get(i - this.requiredArguments.size());
+						: this.optionalArguments.get(i - this.requiredArguments.count());
 
 				valuesByName.put(arg.getName(), rawValue);
 				positionalArgNames.add(arg.getName());
@@ -184,7 +180,7 @@ public abstract sealed class Command permits
 			final int delim = indexOfNameDelim(rawValue);
 			if (delim < EARLIEST_ARG_DELIM_INDEX) {
 				throw new ArgumentHelpException(
-						"Found unnamed positional argument after named a argument; "
+					this, "Found unnamed positional argument after named a argument; "
 							+ "all positional arguments must come before any named arguments. Unnamed argument:\n\t"
 							+ rawValue
 				);
@@ -193,21 +189,18 @@ public abstract sealed class Command permits
 			}
 		}
 
-		for (final Argument<?> require : this.requiredArguments) {
-			if (!valuesByName.containsKey(require.getName())) {
-				throw new ArgumentHelpException("Missing required '%s' argument.".formatted(require.getName()));
-			}
-		}
-
-		this.runImpl(valuesByName);
+		this.runImpl(
+				this.requiredArguments.parse(valuesByName, Argument::requireFrom),
+				this.optionalArguments.parse(valuesByName, Argument::from)
+		);
 	}
 
 	/**
 	 * Executes this command.
-	 * @param args a map associating arguments' names with their values;
-	 * 				values for required argument names are guaranteed to be non-null
+	 * @param required packed non-null required argument values
+	 * @param optional packed optional argument values
 	 */
-	protected abstract void runImpl(Map<String, String> args) throws Exception;
+	abstract void runImpl(R required, O optional) throws Exception;
 
 	/**
 	 * Returns the name of this command. Should be all-lowercase, and separated by dashes for words.
@@ -362,14 +355,17 @@ public abstract sealed class Command permits
 		}
 	}
 
-	protected class ArgumentHelpException extends HelpException {
-		protected ArgumentHelpException(String message) {
+	protected static class ArgumentHelpException extends HelpException {
+		private final Command<?, ?> command;
+
+		protected ArgumentHelpException(Command<?, ?> command, String message) {
 			super(message);
+			this.command = command;
 		}
 
 		@Override
-		public Command getCommand() {
-			return Command.this;
+		public Command<?, ?> getCommand() {
+			return this.command;
 		}
 	}
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -37,6 +37,12 @@ import javax.annotation.Nullable;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
+/**
+ * Represents a command that can be run on the command line.
+ *
+ * @param <R> the type that holds this command's required arguments
+ * @param <O> the type that holds this command's optional arguments
+ */
 public abstract sealed class Command<R, O> permits
 		CheckMappingsCommand, ComposeMappingsCommand, ConvertMappingsCommand, DecompileCommand, DeobfuscateCommand,
 		DropInvalidMappingsCommand, FillClassMappingsCommand, HelpCommand, InsertProposedMappingsCommand,

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -1,5 +1,6 @@
 package org.quiltmc.enigma.command;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.EnigmaProfile;
@@ -27,18 +28,27 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 
 public abstract sealed class Command permits
 		CheckMappingsCommand, ComposeMappingsCommand, ConvertMappingsCommand, DecompileCommand, DeobfuscateCommand,
 		DropInvalidMappingsCommand, FillClassMappingsCommand, HelpCommand, InsertProposedMappingsCommand,
 		InvertMappingsCommand, MapSpecializedMethodsCommand, PrintStatsCommand {
+	private static final int EARLIEST_ARG_DELIM_INDEX = 1;
+
+	@VisibleForTesting
 	final ImmutableList<Argument> requiredArguments;
+	@VisibleForTesting
 	final ImmutableList<Argument> optionalArguments;
 
-	final int totalArgumentCount;
+	private final int totalArgumentCount;
 
 	Command(Argument... requiredArguments) {
 		this(ImmutableList.copyOf(requiredArguments), ImmutableList.of());
@@ -64,10 +74,40 @@ public abstract sealed class Command permits
 	}
 
 	private static void appendArguments(StringBuilder builder, List<Argument> arguments) {
-		for (int i = 0; i < arguments.size(); i++) {
-			builder.append(arguments.get(i).displayForm());
-			if (i < arguments.size() - 1) {
+		final int argCount = arguments.size();
+		final int iLastArg = argCount - 1;
+		for (int i = 0; i < argCount; i++) {
+			builder.append(arguments.get(i).getDisplayForm());
+			if (i < iLastArg) {
 				builder.append(" ");
+			}
+		}
+	}
+
+	private static void appendArgHelp(Argument argument, int index, StringBuilder builder) {
+		builder.append("Argument ").append(index).append(": ").append(argument.getDisplayForm()).append("\n");
+		builder.append(argument.getExplanation()).append("\n");
+	}
+
+	final void appendHelp(StringBuilder builder) {
+		builder.append("\t\t").append(this.getName()).append(" ").append(this.getUsage()).append("\n");
+
+		if (!this.requiredArguments.isEmpty()) {
+			builder.append("Arguments:").append("\n");
+			int argIndex = 0;
+			for (int j = 0; j < this.requiredArguments.size(); j++) {
+				Argument argument = this.requiredArguments.get(j);
+				appendArgHelp(argument, argIndex, builder);
+				argIndex++;
+			}
+
+			if (!this.optionalArguments.isEmpty()) {
+				builder.append("\n").append("Optional arguments:").append("\n");
+				for (int i = 0; i < this.optionalArguments.size(); i++) {
+					Argument argument = this.optionalArguments.get(i);
+					appendArgHelp(argument, argIndex, builder);
+					argIndex++;
+				}
 			}
 		}
 	}
@@ -83,10 +123,93 @@ public abstract sealed class Command permits
 
 	/**
 	 * Executes this command.
-	 * @param args the command-line arguments, to be parsed with {@link #getArg(String[], int)}
+	 * @param args the command-line arguments
 	 * @throws Exception on any error
 	 */
-	public abstract void run(String... args) throws Exception;
+	public final void run(String... args) throws Exception {
+		if (args.length < this.requiredArguments.size()) {
+			throw new ArgumentHelpException(
+					"Too few arguments (%s); at least %s %s required.".formatted(
+						args.length,
+						this.requiredArguments.size() == 1 ? "is" : "are",
+						this.requiredArguments.size()
+					)
+			);
+		} else if (args.length > this.totalArgumentCount) {
+			throw new ArgumentHelpException(
+					"Too many arguments (%s); at most %s %s allowed.".formatted(
+						args.length,
+						this.totalArgumentCount == 1 ? "is" : "are",
+						this.totalArgumentCount
+					)
+			);
+		}
+
+		final Map<String, String> valuesByName = new HashMap<>();
+		final Set<String> positionalArgNames = new HashSet<>();
+
+		final BiConsumer<String, Integer> addNamedArg = (rawValue, delim) -> {
+			final String name = rawValue.substring(0, delim);
+			if (positionalArgNames.contains(name)) {
+				throw new ArgumentHelpException("'%s' specified as both positional and named argument.".formatted(name));
+			}
+
+			final String value = rawValue.substring(delim + 1);
+			if (valuesByName.put(name, value) != null) {
+				throw new ArgumentHelpException("'%s' argument named more than once.".formatted(name));
+			}
+		};
+
+		int i = 0;
+		// leading positional args
+		for (; i < args.length; i++) {
+			final String rawValue = args[i];
+			final int delim = indexOfNameDelim(rawValue);
+			if (delim < EARLIEST_ARG_DELIM_INDEX) {
+				final Argument arg = i < this.requiredArguments.size()
+						? this.requiredArguments.get(i)
+						: this.optionalArguments.get(i - this.requiredArguments.size());
+
+				valuesByName.put(arg.getName(), rawValue);
+				positionalArgNames.add(arg.getName());
+			} else {
+				// first named arg
+				addNamedArg.accept(rawValue, delim);
+				i++;
+				break;
+			}
+		}
+
+		// trailing named args
+		for (; i < args.length; i++) {
+			final String rawValue = args[i];
+			final int delim = indexOfNameDelim(rawValue);
+			if (delim < EARLIEST_ARG_DELIM_INDEX) {
+				throw new ArgumentHelpException(
+						"Found unnamed positional argument after named a argument; "
+							+ "all positional arguments must come before any named arguments. Unnamed argument:\n\t"
+							+ rawValue
+				);
+			} else {
+				addNamedArg.accept(rawValue, delim);
+			}
+		}
+
+		for (final Argument require : this.requiredArguments) {
+			if (!valuesByName.containsKey(require.getName())) {
+				throw new ArgumentHelpException("Missing required '%s' argument.".formatted(require.getName()));
+			}
+		}
+
+		this.runImpl(valuesByName);
+	}
+
+	/**
+	 * Executes this command.
+	 * @param args a map associating arguments' names with their values;
+	 * 				values for required argument names are guaranteed to be non-null
+	 */
+	protected abstract void runImpl(Map<String, String> args) throws Exception;
 
 	/**
 	 * Returns the name of this command. Should be all-lowercase, and separated by dashes for words.
@@ -248,13 +371,26 @@ public abstract sealed class Command permits
 	private static String getArg(String[] args, int index, Argument argument, boolean optional) {
 		if (index >= args.length) {
 			if (!optional) {
-				throw new IllegalArgumentException(argument.displayForm() + " is required");
+				throw new IllegalArgumentException(argument.getName() + " is required");
 			} else {
 				return null;
 			}
 		}
 
 		return args[index];
+	}
+
+	private static int indexOfNameDelim(String argValue) {
+		for (int ic = 0; ic < argValue.length(); ic++) {
+			final char c = argValue.charAt(ic);
+			if (c == Argument.SEPARATOR) {
+				return -1;
+			} else if (c == Argument.NAME_DELIM) {
+				return ic;
+			}
+		}
+
+		return -1;
 	}
 
 	protected static boolean shouldDebug(String name) {
@@ -308,6 +444,29 @@ public abstract sealed class Command permits
 				double elapsedSeconds = (now - this.startTime) / 1000.0;
 				Logger.info("Finished in {} seconds", elapsedSeconds);
 			}
+		}
+	}
+
+	abstract static class HelpException extends RuntimeException {
+		protected abstract Command getCommand();
+
+		HelpException(String message) {
+			super(message);
+		}
+
+		HelpException(Throwable cause) {
+			super(cause);
+		}
+	}
+
+	protected class ArgumentHelpException extends HelpException {
+		protected ArgumentHelpException(String message) {
+			super(message);
+		}
+
+		@Override
+		public Command getCommand() {
+			return Command.this;
 		}
 	}
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -209,7 +209,7 @@ public abstract sealed class Command<R, O> permits
 			final int delim = indexOfNameDelim(rawValue);
 			if (delim < EARLIEST_ARG_DELIM_INDEX) {
 				throw new ArgumentHelpException(
-					this, "Found unnamed positional argument after named a argument; "
+					this, "Found unnamed positional argument after a named argument; "
 							+ "all positional arguments must come before any named arguments. Unnamed argument:\n\t"
 							+ rawValue
 				);

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -131,7 +131,7 @@ public abstract sealed class Command<R, O> permits
 		final Map<String, String> valuesByName = this.buildValuesByName(args);
 
 		this.runImpl(
-				this.requiredArguments.parse(valuesByName, Argument::requireFrom),
+				this.parseRequired(valuesByName),
 				this.optionalArguments.parse(valuesByName, Argument::from)
 		);
 	}
@@ -213,6 +213,15 @@ public abstract sealed class Command<R, O> permits
 		}
 
 		return valuesByName;
+	}
+
+	@VisibleForTesting
+	R parseRequired(Map<String, String> valuesByName) {
+		try {
+			return this.requiredArguments.parse(valuesByName, Argument::requireFrom);
+		} catch (IllegalArgumentException e) {
+			throw new ArgumentHelpException(this, e);
+		}
 	}
 
 	/**
@@ -375,11 +384,17 @@ public abstract sealed class Command<R, O> permits
 		}
 	}
 
-	protected static class ArgumentHelpException extends HelpException {
+	@VisibleForTesting
+	static class ArgumentHelpException extends HelpException {
 		private final Command<?, ?> command;
 
-		protected ArgumentHelpException(Command<?, ?> command, String message) {
+		ArgumentHelpException(Command<?, ?> command, String message) {
 			super(message);
+			this.command = command;
+		}
+
+		ArgumentHelpException(Command<?, ?> command, Throwable cause) {
+			super(cause);
 			this.command = command;
 		}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Command.java
@@ -119,6 +119,16 @@ public abstract sealed class Command<R, O> permits
 	 * @throws Exception on any error
 	 */
 	public final void run(String... args) throws Exception {
+		final Map<String, String> valuesByName = this.buildValuesByName(args);
+
+		this.runImpl(
+				this.requiredArguments.parse(valuesByName, Argument::requireFrom),
+				this.optionalArguments.parse(valuesByName, Argument::from)
+		);
+	}
+
+	@VisibleForTesting
+	Map<String, String> buildValuesByName(String[] args) {
 		if (args.length < this.requiredArguments.count()) {
 			throw new ArgumentHelpException(
 				this, "Too few arguments (%s); at least %s %s required.".formatted(
@@ -189,10 +199,7 @@ public abstract sealed class Command<R, O> permits
 			}
 		}
 
-		this.runImpl(
-				this.requiredArguments.parse(valuesByName, Argument::requireFrom),
-				this.optionalArguments.parse(valuesByName, Argument::from)
-		);
+		return valuesByName;
 	}
 
 	/**

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/CommonArguments.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/CommonArguments.java
@@ -5,31 +5,31 @@ final class CommonArguments {
 		throw new UnsupportedOperationException();
 	}
 
-	static final Argument INPUT_JAR = new Argument("<input-jar>",
+	static final Argument INPUT_JAR = Argument.ofPath("input-jar",
 			"""
 					A path to the .jar file to use in executing the command."""
 	);
-	static final Argument INPUT_MAPPINGS = new Argument("<input-mappings>",
+	static final Argument INPUT_MAPPINGS = Argument.ofPath("input-mappings",
 			"""
 					A path to the file or folder to read mappings from."""
 	);
-	static final Argument MAPPING_OUTPUT = new Argument("<mapping-output>",
+	static final Argument MAPPING_OUTPUT = Argument.ofPath("mapping-output",
 			"""
 					A path to the file or folder to write mappings to. Will be created if missing."""
 	);
-	static final Argument OUTPUT_JAR = new Argument("<output-jar>",
+	static final Argument OUTPUT_JAR = Argument.ofPath("output-jar",
 			"""
 					A path to the .jar file to write output to. Will be created if missing."""
 	);
-	static final Argument ENIGMA_PROFILE = new Argument("<enigma-profile>",
+	static final Argument ENIGMA_PROFILE = Argument.ofPath("enigma-profile",
 			"""
 					A path to an Enigma profile JSON file, used to apply things like plugins."""
 	);
-	static final Argument OBFUSCATED_NAMESPACE = new Argument("<obfuscated-namespace>",
+	static final Argument OBFUSCATED_NAMESPACE = new Argument("obfuscated-namespace", "namespace",
 			"""
 					The namespace to use for obfuscated names when writing mappings. Only used in certain mapping formats."""
 	);
-	static final Argument DEOBFUSCATED_NAMESPACE = new Argument("<deobfuscated-namespace>",
+	static final Argument DEOBFUSCATED_NAMESPACE = new Argument("deobfuscated-namespace", "namespace",
 			"""
 					The namespace to use for deobfuscated names when writing mappings. Only used in certain mapping formats."""
 	);

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/CommonArguments.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/CommonArguments.java
@@ -1,35 +1,37 @@
 package org.quiltmc.enigma.command;
 
+import java.nio.file.Path;
+
 final class CommonArguments {
 	private CommonArguments() {
 		throw new UnsupportedOperationException();
 	}
 
-	static final Argument INPUT_JAR = Argument.ofPath("input-jar",
+	static final Argument<Path> INPUT_JAR = Argument.ofReadableFile("input-jar",
 			"""
 					A path to the .jar file to use in executing the command."""
 	);
-	static final Argument INPUT_MAPPINGS = Argument.ofPath("input-mappings",
+	static final Argument<Path> INPUT_MAPPINGS = Argument.ofReadablePath("input-mappings",
 			"""
 					A path to the file or folder to read mappings from."""
 	);
-	static final Argument MAPPING_OUTPUT = Argument.ofPath("mapping-output",
+	static final Argument<Path> MAPPING_OUTPUT = Argument.ofWritablePath("mapping-output",
 			"""
 					A path to the file or folder to write mappings to. Will be created if missing."""
 	);
-	static final Argument OUTPUT_JAR = Argument.ofPath("output-jar",
+	static final Argument<Path> OUTPUT_JAR = Argument.ofWritableFile("output-jar",
 			"""
 					A path to the .jar file to write output to. Will be created if missing."""
 	);
-	static final Argument ENIGMA_PROFILE = Argument.ofPath("enigma-profile",
+	static final Argument<Path> ENIGMA_PROFILE = Argument.ofReadableFile("enigma-profile",
 			"""
 					A path to an Enigma profile JSON file, used to apply things like plugins."""
 	);
-	static final Argument OBFUSCATED_NAMESPACE = new Argument("obfuscated-namespace", "namespace",
+	static final Argument<String> OBFUSCATED_NAMESPACE = Argument.ofString("obfuscated-namespace", "namespace",
 			"""
 					The namespace to use for obfuscated names when writing mappings. Only used in certain mapping formats."""
 	);
-	static final Argument DEOBFUSCATED_NAMESPACE = new Argument("deobfuscated-namespace", "namespace",
+	static final Argument<String> DEOBFUSCATED_NAMESPACE = Argument.ofString("deobfuscated-namespace", "namespace",
 			"""
 					The namespace to use for deobfuscated names when writing mappings. Only used in certain mapping formats."""
 	);

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/ComposeMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/ComposeMappingsCommand.java
@@ -24,15 +24,15 @@ import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 import static org.quiltmc.enigma.util.Utils.andJoin;
 
 public final class ComposeMappingsCommand extends Command {
-	private static final Argument LEFT_MAPPINGS = Argument.ofPath("left-mappings",
+	private static final Argument<Path> LEFT_MAPPINGS = Argument.ofReadablePath("left-mappings",
 			"""
 					A path to the left file or folder to read mappings from, used in commands which take two mapping inputs."""
 	);
-	private static final Argument RIGHT_MAPPINGS = Argument.ofPath("right-mappings",
+	private static final Argument<Path> RIGHT_MAPPINGS = Argument.ofReadablePath("right-mappings",
 			"""
 					A path to the right file or folder to read mappings from, used in commands which take two mapping inputs."""
 	);
-	private static final Argument KEEP_MODE = Argument.ofEnum("keep-mode", KeepMode.class,
+	private static final Argument<String> KEEP_MODE = Argument.ofLenientEnum("keep-mode", KeepMode.class,
 			"""
 					Which mappings should overwrite the others when composing conflicting mappings. Allowed values are """
 				+ andJoin(KeepMode.VALUES.stream().map(Object::toString).map(mode -> '"' + mode + '"').toList())
@@ -41,18 +41,18 @@ public final class ComposeMappingsCommand extends Command {
 	public static final ComposeMappingsCommand INSTANCE = new ComposeMappingsCommand();
 
 	private ComposeMappingsCommand() {
-		super(LEFT_MAPPINGS, RIGHT_MAPPINGS, MAPPING_OUTPUT, KEEP_MODE);
+		super(
+				ImmutableList.of(LEFT_MAPPINGS, RIGHT_MAPPINGS, MAPPING_OUTPUT, KEEP_MODE),
+				ImmutableList.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
+		);
 	}
 
 	@Override
 	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
 		run(
-				getReadablePath(args.get(LEFT_MAPPINGS.getName())),
-				getReadablePath(args.get(RIGHT_MAPPINGS.getName())),
-				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
-				args.get(KEEP_MODE.getName()),
-				args.get(OBFUSCATED_NAMESPACE.getName()),
-				args.get(DEOBFUSCATED_NAMESPACE.getName())
+				LEFT_MAPPINGS.get(args), RIGHT_MAPPINGS.get(args),
+				MAPPING_OUTPUT.get(args), KEEP_MODE.get(args),
+				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
 		);
 	}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/ComposeMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/ComposeMappingsCommand.java
@@ -12,18 +12,19 @@ import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingsWriter;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
 import org.quiltmc.enigma.util.Utils;
+import org.quiltmc.enigma.command.ComposeMappingsCommand.Required;
+import org.quiltmc.enigma.command.ComposeMappingsCommand.Optional;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Map;
 
 import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
 import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 import static org.quiltmc.enigma.util.Utils.andJoin;
 
-public final class ComposeMappingsCommand extends Command {
+public final class ComposeMappingsCommand extends Command<Required, Optional> {
 	private static final Argument<Path> LEFT_MAPPINGS = Argument.ofReadablePath("left-mappings",
 			"""
 					A path to the left file or folder to read mappings from, used in commands which take two mapping inputs."""
@@ -42,17 +43,17 @@ public final class ComposeMappingsCommand extends Command {
 
 	private ComposeMappingsCommand() {
 		super(
-				ImmutableList.of(LEFT_MAPPINGS, RIGHT_MAPPINGS, MAPPING_OUTPUT, KEEP_MODE),
-				ImmutableList.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
+				ArgsParser.of(LEFT_MAPPINGS, RIGHT_MAPPINGS, MAPPING_OUTPUT, KEEP_MODE, Required::new),
+				ArgsParser.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE, Optional::new)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
+	void runImpl(Required required, Optional optional) throws IOException, MappingParseException {
 		run(
-				LEFT_MAPPINGS.get(args), RIGHT_MAPPINGS.get(args),
-				MAPPING_OUTPUT.get(args), KEEP_MODE.get(args),
-				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
+				required.leftMappings, required.rightMappings,
+				required.mappingsOutput, required.keepMode,
+				optional.obfuscatedNamespace, optional.deobfuscatedNamespace
 		);
 	}
 
@@ -132,4 +133,8 @@ public final class ComposeMappingsCommand extends Command {
 			return this.value;
 		}
 	}
+
+	record Required(Path leftMappings, Path rightMappings, Path mappingsOutput, String keepMode) { }
+
+	record Optional(String obfuscatedNamespace, String deobfuscatedNamespace) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/ConvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/ConvertMappingsCommand.java
@@ -31,10 +31,8 @@ public final class ConvertMappingsCommand extends Command {
 	@Override
 	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
 		run(
-				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
-				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
-				args.get(OBFUSCATED_NAMESPACE.getName()),
-				args.get(DEOBFUSCATED_NAMESPACE.getName())
+				INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
+				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
 		);
 	}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/ConvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/ConvertMappingsCommand.java
@@ -9,30 +9,37 @@ import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingsReader;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingsWriter;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
+import org.quiltmc.enigma.command.ArgsParser.Empty;
 import org.quiltmc.enigma.util.Utils;
+import org.quiltmc.enigma.command.ConvertMappingsCommand.Required;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Map;
 
 import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
-public final class ConvertMappingsCommand extends Command {
+public final class ConvertMappingsCommand extends Command<Required, Empty> {
 	public static final ConvertMappingsCommand INSTANCE = new ConvertMappingsCommand();
 
 	private ConvertMappingsCommand() {
-		super(INPUT_MAPPINGS, MAPPING_OUTPUT, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE);
+		super(
+				ArgsParser.of(
+					INPUT_MAPPINGS, MAPPING_OUTPUT, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE,
+					Required::new
+				),
+				Empty.PARSER
+		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
+	void runImpl(Required required, Empty optional) throws IOException, MappingParseException {
 		run(
-				INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
-				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
+				required.inputMappings, required.mappingOutput,
+				required.obfuscatedNamespace, required.deobfuscatedNamespace
 		);
 	}
 
@@ -57,4 +64,9 @@ public final class ConvertMappingsCommand extends Command {
 		MappingsWriter writer = CommandsUtil.getWriter(enigma, output);
 		writer.write(mappings, output, ProgressListener.createEmpty(), saveParameters);
 	}
+
+	record Required(
+			Path inputMappings, Path mappingOutput,
+			String obfuscatedNamespace, String deobfuscatedNamespace
+	) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/ConvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/ConvertMappingsCommand.java
@@ -14,27 +14,28 @@ import org.quiltmc.enigma.util.Utils;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
+import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
 public final class ConvertMappingsCommand extends Command {
 	public static final ConvertMappingsCommand INSTANCE = new ConvertMappingsCommand();
 
 	private ConvertMappingsCommand() {
-		super(
-				CommonArguments.INPUT_MAPPINGS,
-				CommonArguments.MAPPING_OUTPUT,
-				CommonArguments.OBFUSCATED_NAMESPACE,
-				CommonArguments.DEOBFUSCATED_NAMESPACE
-		);
+		super(INPUT_MAPPINGS, MAPPING_OUTPUT, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE);
 	}
 
 	@Override
-	public void run(String... args) throws IOException, MappingParseException {
-		Path source = getReadablePath(this.getArg(args, 0));
-		Path result = getWritablePath(this.getArg(args, 1));
-		String obfuscatedNamespace = this.getArg(args, 2);
-		String deobfuscatedNamespace = this.getArg(args, 3);
-
-		run(source, result, obfuscatedNamespace, deobfuscatedNamespace);
+	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
+		run(
+				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
+				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
+				args.get(OBFUSCATED_NAMESPACE.getName()),
+				args.get(DEOBFUSCATED_NAMESPACE.getName())
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
@@ -19,7 +19,7 @@ import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.OUTPUT_JAR;
 
 public final class DecompileCommand extends Command {
-	private static final Argument DECOMPILER = Argument.ofEnum("decompiler", Decompiler.class,
+	private static final Argument<String> DECOMPILER = Argument.ofLenientEnum("decompiler", Decompiler.class,
 			"""
 					The decompiler to use when producing output. Allowed values are (case-insensitive):"""
 				+ Decompiler.VALUES.stream()
@@ -39,12 +39,7 @@ public final class DecompileCommand extends Command {
 
 	@Override
 	protected void runImpl(Map<String, String> args) throws Exception {
-		run(
-				args.get(DECOMPILER.getName()),
-				getReadableFile(args.get(INPUT_JAR.getName())).toPath(),
-				getWritableFolder(args.get(OUTPUT_JAR.getName())).toPath(),
-				getReadablePath(args.get(INPUT_MAPPINGS.getName()))
-		);
+		run(DECOMPILER.get(args), INPUT_JAR.get(args), OUTPUT_JAR.get(args), INPUT_MAPPINGS.get(args));
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
@@ -52,6 +52,10 @@ public final class DecompileCommand extends Command {
 		return "Decompiles the provided jar into human-readable code.";
 	}
 
+	public static void run(Decompiler decompiler, Path fileJarIn, Path fileJarOut, Path fileMappings) throws Exception {
+		run(decompiler.toString(), fileJarIn, fileJarOut, fileMappings);
+	}
+
 	public static void run(String decompilerName, Path fileJarIn, Path fileJarOut, Path fileMappings) throws Exception {
 		DecompilerService decompilerService;
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
@@ -6,19 +6,19 @@ import org.quiltmc.enigma.api.ProgressListener;
 import org.quiltmc.enigma.api.EnigmaProject.DecompileErrorStrategy;
 import org.quiltmc.enigma.api.service.DecompilerService;
 import org.quiltmc.enigma.api.source.Decompilers;
+import org.quiltmc.enigma.command.DecompileCommand.Required;
 import org.tinylog.Logger;
 
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.OUTPUT_JAR;
 
-public final class DecompileCommand extends Command {
+public final class DecompileCommand extends Command<Required, Path> {
 	private static final Argument<String> DECOMPILER = Argument.ofLenientEnum("decompiler", Decompiler.class,
 			"""
 					The decompiler to use when producing output. Allowed values are (case-insensitive):"""
@@ -32,14 +32,14 @@ public final class DecompileCommand extends Command {
 
 	private DecompileCommand() {
 		super(
-				ImmutableList.of(DECOMPILER, INPUT_JAR, OUTPUT_JAR),
-				ImmutableList.of(INPUT_MAPPINGS)
+				ArgsParser.of(DECOMPILER, INPUT_JAR, OUTPUT_JAR, Required::new),
+				ArgsParser.of(INPUT_MAPPINGS)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
-		run(DECOMPILER.get(args), INPUT_JAR.get(args), OUTPUT_JAR.get(args), INPUT_MAPPINGS.get(args));
+	void runImpl(Required required, Path inputMappings) throws Exception {
+		run(required.decompiler, required.inputJar, required.outputJar, inputMappings);
 	}
 
 	@Override
@@ -82,4 +82,6 @@ public final class DecompileCommand extends Command {
 
 		public static final ImmutableList<Decompiler> VALUES = ImmutableList.copyOf(values());
 	}
+
+	record Required(String decompiler, Path inputJar, Path outputJar) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DeobfuscateCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DeobfuscateCommand.java
@@ -5,24 +5,29 @@ import org.quiltmc.enigma.api.EnigmaProject;
 import org.quiltmc.enigma.api.ProgressListener;
 
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.OUTPUT_JAR;
 
 public final class DeobfuscateCommand extends Command {
 	public static final DeobfuscateCommand INSTANCE = new DeobfuscateCommand();
 
 	private DeobfuscateCommand() {
 		super(
-				ImmutableList.of(CommonArguments.INPUT_JAR, CommonArguments.OUTPUT_JAR),
-				ImmutableList.of(CommonArguments.INPUT_MAPPINGS)
+				ImmutableList.of(INPUT_JAR, OUTPUT_JAR),
+				ImmutableList.of(INPUT_MAPPINGS)
 		);
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
-		Path fileJarIn = getReadablePath(this.getArg(args, 0));
-		Path fileJarOut = getWritableFile(this.getArg(args, 1)).toPath();
-		Path fileMappings = getReadablePath(this.getArg(args, 2));
-
-		run(fileJarIn, fileJarOut, fileMappings);
+	protected void runImpl(Map<String, String> args) throws Exception {
+		run(
+				getReadablePath(args.get(INPUT_JAR.getName())),
+				getWritableFile(args.get(OUTPUT_JAR.getName())).toPath(),
+				getReadablePath(args.get(INPUT_MAPPINGS.getName()))
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DeobfuscateCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DeobfuscateCommand.java
@@ -1,29 +1,28 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.EnigmaProject;
 import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.command.DeobfuscateCommand.Required;
 
 import java.nio.file.Path;
-import java.util.Map;
 
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.OUTPUT_JAR;
 
-public final class DeobfuscateCommand extends Command {
+public final class DeobfuscateCommand extends Command<Required, Path> {
 	public static final DeobfuscateCommand INSTANCE = new DeobfuscateCommand();
 
 	private DeobfuscateCommand() {
 		super(
-				ImmutableList.of(INPUT_JAR, OUTPUT_JAR),
-				ImmutableList.of(INPUT_MAPPINGS)
+				ArgsParser.of(INPUT_JAR, OUTPUT_JAR, Required::new),
+				ArgsParser.of(INPUT_MAPPINGS)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
-		run(INPUT_JAR.get(args), OUTPUT_JAR.get(args), INPUT_MAPPINGS.get(args));
+	void runImpl(Required required, Path inputMappings) throws Exception {
+		run(required.inputJar, required.outputJar, inputMappings);
 	}
 
 	@Override
@@ -44,4 +43,6 @@ public final class DeobfuscateCommand extends Command {
 		EnigmaProject.JarExport jar = project.exportRemappedJar(progress);
 		jar.write(fileJarOut, progress);
 	}
+
+	record Required(Path inputJar, Path outputJar) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DeobfuscateCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DeobfuscateCommand.java
@@ -23,11 +23,7 @@ public final class DeobfuscateCommand extends Command {
 
 	@Override
 	protected void runImpl(Map<String, String> args) throws Exception {
-		run(
-				getReadablePath(args.get(INPUT_JAR.getName())),
-				getWritableFile(args.get(OUTPUT_JAR.getName())).toPath(),
-				getReadablePath(args.get(INPUT_MAPPINGS.getName()))
-		);
+		run(INPUT_JAR.get(args), OUTPUT_JAR.get(args), INPUT_MAPPINGS.get(args));
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DropInvalidMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DropInvalidMappingsCommand.java
@@ -31,11 +31,10 @@ public final class DropInvalidMappingsCommand extends Command {
 
 	@Override
 	protected void runImpl(Map<String, String> args) throws Exception {
-		Path jarIn = getReadablePath(args.get(INPUT_JAR.getName()));
-		Path mappingsIn = getReadablePath(args.get(INPUT_MAPPINGS.getName()));
-		String mappingsOutArg = args.get(MAPPING_OUTPUT.getName());
-		Path mappingsOut = mappingsOutArg != null && !mappingsOutArg.isEmpty()
-				? getReadablePath(mappingsOutArg) : mappingsIn;
+		Path jarIn = INPUT_JAR.get(args);
+		Path mappingsIn = INPUT_MAPPINGS.get(args);
+		Path mappingsOutArg = MAPPING_OUTPUT.get(args);
+		Path mappingsOut = mappingsOutArg != null ? mappingsOutArg : mappingsIn;
 
 		run(jarIn, mappingsIn, mappingsOut);
 	}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DropInvalidMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DropInvalidMappingsCommand.java
@@ -1,10 +1,10 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.EnigmaProject;
 import org.quiltmc.enigma.api.ProgressListener;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingsWriter;
+import org.quiltmc.enigma.command.DropInvalidMappingsCommand.Required;
 import org.tinylog.Logger;
 
 import java.io.IOException;
@@ -13,27 +13,26 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Map;
 
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 
-public final class DropInvalidMappingsCommand extends Command {
+public final class DropInvalidMappingsCommand extends Command<Required, Path> {
 	public static final DropInvalidMappingsCommand INSTANCE = new DropInvalidMappingsCommand();
 
 	private DropInvalidMappingsCommand() {
 		super(
-				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS),
-				ImmutableList.of(MAPPING_OUTPUT)
+				ArgsParser.of(INPUT_JAR, INPUT_MAPPINGS, Required::new),
+				ArgsParser.of(MAPPING_OUTPUT)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
-		Path jarIn = INPUT_JAR.get(args);
-		Path mappingsIn = INPUT_MAPPINGS.get(args);
-		Path mappingsOutArg = MAPPING_OUTPUT.get(args);
+	void runImpl(Required required, Path mappingOutput) throws Exception {
+		Path jarIn = required.inputJar;
+		Path mappingsIn = required.inputMappings;
+		Path mappingsOutArg = mappingOutput;
 		Path mappingsOut = mappingsOutArg != null ? mappingsOutArg : mappingsIn;
 
 		run(jarIn, mappingsIn, mappingsOut);
@@ -91,4 +90,6 @@ public final class DropInvalidMappingsCommand extends Command {
 			Logger.info("No invalid mappings found.");
 		}
 	}
+
+	record Required(Path inputJar, Path inputMappings) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DropInvalidMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DropInvalidMappingsCommand.java
@@ -13,23 +13,29 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Map;
+
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 
 public final class DropInvalidMappingsCommand extends Command {
 	public static final DropInvalidMappingsCommand INSTANCE = new DropInvalidMappingsCommand();
 
 	private DropInvalidMappingsCommand() {
 		super(
-				ImmutableList.of(CommonArguments.INPUT_JAR, CommonArguments.INPUT_MAPPINGS),
-				ImmutableList.of(CommonArguments.MAPPING_OUTPUT)
+				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS),
+				ImmutableList.of(MAPPING_OUTPUT)
 		);
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
-		Path jarIn = getReadablePath(this.getArg(args, 0));
-		Path mappingsIn = getReadablePath(this.getArg(args, 1));
-		String mappingsOutArg = this.getArg(args, 2);
-		Path mappingsOut = mappingsOutArg != null && !mappingsOutArg.isEmpty() ? getReadablePath(mappingsOutArg) : mappingsIn;
+	protected void runImpl(Map<String, String> args) throws Exception {
+		Path jarIn = getReadablePath(args.get(INPUT_JAR.getName()));
+		Path mappingsIn = getReadablePath(args.get(INPUT_MAPPINGS.getName()));
+		String mappingsOutArg = args.get(MAPPING_OUTPUT.getName());
+		Path mappingsOut = mappingsOutArg != null && !mappingsOutArg.isEmpty()
+				? getReadablePath(mappingsOutArg) : mappingsIn;
 
 		run(jarIn, mappingsIn, mappingsOut);
 	}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/FillClassMappingsCommand.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.ProgressListener;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
@@ -15,12 +14,13 @@ import org.quiltmc.enigma.api.translation.mapping.tree.HashEntryTree;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.ParentedEntry;
 import org.quiltmc.enigma.util.Utils;
+import org.quiltmc.enigma.command.FillClassMappingsCommand.Required;
+import org.quiltmc.enigma.command.FillClassMappingsCommand.Optional;
 import org.tinylog.Logger;
 
 import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 
 import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
@@ -28,7 +28,7 @@ import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
-public final class FillClassMappingsCommand extends Command {
+public final class FillClassMappingsCommand extends Command<Required, Optional> {
 	private static final Argument<Boolean> FILL_ALL = Argument.ofBool("fill-all",
 			"""
 					Whether to fill all possible mappings. Allowed values are "true" and "false"."""
@@ -38,17 +38,16 @@ public final class FillClassMappingsCommand extends Command {
 
 	private FillClassMappingsCommand() {
 		super(
-				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT),
-				ImmutableList.of(FILL_ALL, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
+				ArgsParser.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT, Required::new),
+				ArgsParser.of(FILL_ALL, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE, Optional::new)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
+	void runImpl(Required required, Optional optional) throws Exception {
 		run(
-				INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
-				FILL_ALL.get(args),
-				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
+				required.inputJar, required.inputMappings, required.mappingOutput,
+				optional.fillAll, optional.obfuscatedNamespace, optional.deobfuscatedNamespace
 		);
 	}
 
@@ -131,4 +130,8 @@ public final class FillClassMappingsCommand extends Command {
 			}
 		}
 	}
+
+	record Required(Path inputJar, Path inputMappings, Path mappingOutput) { }
+
+	record Optional(boolean fillAll, String obfuscatedNamespace, String deobfuscatedNamespace) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/FillClassMappingsCommand.java
@@ -20,9 +20,16 @@ import org.tinylog.Logger;
 import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+
+import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
+import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
 public final class FillClassMappingsCommand extends Command {
-	private static final Argument FILL_ALL = new Argument("<fill-all>",
+	private static final Argument FILL_ALL = Argument.ofBool("fill-all",
 			"""
 					Whether to fill all possible mappings. Allowed values are "true" and "false"."""
 	);
@@ -31,25 +38,21 @@ public final class FillClassMappingsCommand extends Command {
 
 	private FillClassMappingsCommand() {
 		super(
-				ImmutableList.of(
-						CommonArguments.INPUT_JAR,
-						CommonArguments.INPUT_MAPPINGS,
-						CommonArguments.MAPPING_OUTPUT
-				),
-				ImmutableList.of(FILL_ALL, CommonArguments.OBFUSCATED_NAMESPACE, CommonArguments.DEOBFUSCATED_NAMESPACE)
+				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT),
+				ImmutableList.of(FILL_ALL, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
 		);
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
-		Path inJar = getReadablePath(this.getArg(args, 0));
-		Path source = getReadablePath(this.getArg(args, 1));
-		Path result = getWritablePath(this.getArg(args, 2));
-		boolean fillAll = Boolean.parseBoolean(this.getArg(args, 3));
-		String obfuscatedNamespace = this.getArg(args, 4);
-		String deobfuscatedNamespace = this.getArg(args, 5);
-
-		run(inJar, source, result, fillAll, obfuscatedNamespace, deobfuscatedNamespace);
+	protected void runImpl(Map<String, String> args) throws Exception {
+		run(
+				getReadablePath(args.get(INPUT_JAR.getName())),
+				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
+				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
+				Boolean.parseBoolean(args.get(FILL_ALL.getName())),
+				args.get(OBFUSCATED_NAMESPACE.getName()),
+				args.get(DEOBFUSCATED_NAMESPACE.getName())
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/FillClassMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/FillClassMappingsCommand.java
@@ -29,7 +29,7 @@ import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
 public final class FillClassMappingsCommand extends Command {
-	private static final Argument FILL_ALL = Argument.ofBool("fill-all",
+	private static final Argument<Boolean> FILL_ALL = Argument.ofBool("fill-all",
 			"""
 					Whether to fill all possible mappings. Allowed values are "true" and "false"."""
 	);
@@ -46,12 +46,9 @@ public final class FillClassMappingsCommand extends Command {
 	@Override
 	protected void runImpl(Map<String, String> args) throws Exception {
 		run(
-				getReadablePath(args.get(INPUT_JAR.getName())),
-				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
-				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
-				Boolean.parseBoolean(args.get(FILL_ALL.getName())),
-				args.get(OBFUSCATED_NAMESPACE.getName()),
-				args.get(DEOBFUSCATED_NAMESPACE.getName())
+				INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
+				FILL_ALL.get(args),
+				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
 		);
 	}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/HelpCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/HelpCommand.java
@@ -3,6 +3,7 @@ package org.quiltmc.enigma.command;
 import org.tinylog.Logger;
 
 import java.util.Collection;
+import java.util.Map;
 
 public final class HelpCommand extends Command {
 	public static final HelpCommand INSTANCE = new HelpCommand();
@@ -12,7 +13,7 @@ public final class HelpCommand extends Command {
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
+	protected void runImpl(Map<String, String> args) throws Exception {
 		StringBuilder help = new StringBuilder();
 		Collection<Command> commands = Main.getCommands().values();
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/HelpCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/HelpCommand.java
@@ -15,10 +15,10 @@ public final class HelpCommand extends Command<Empty, Empty> {
 	@Override
 	void runImpl(Empty required, Empty optional) throws Exception {
 		StringBuilder help = new StringBuilder();
-		Collection<Command> commands = Main.getCommands().values();
+		Collection<Command<?, ?>> commands = Main.getCommands().values();
 
 		help.append("Supported commands:").append("\n");
-		for (Command command : commands) {
+		for (Command<?, ?> command : commands) {
 			help.append("- ").append(command.getName()).append("\n");
 			help.append("\t").append(command.getDescription()).append("\n");
 		}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/HelpCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/HelpCommand.java
@@ -1,19 +1,19 @@
 package org.quiltmc.enigma.command;
 
+import org.quiltmc.enigma.command.ArgsParser.Empty;
 import org.tinylog.Logger;
 
 import java.util.Collection;
-import java.util.Map;
 
-public final class HelpCommand extends Command {
+public final class HelpCommand extends Command<Empty, Empty> {
 	public static final HelpCommand INSTANCE = new HelpCommand();
 
 	private HelpCommand() {
-		super();
+		super(Empty.PARSER, Empty.PARSER);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
+	void runImpl(Empty required, Empty optional) throws Exception {
 		StringBuilder help = new StringBuilder();
 		Collection<Command> commands = Main.getCommands().values();
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/InsertProposedMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/InsertProposedMappingsCommand.java
@@ -27,34 +27,34 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
+import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
+import static org.quiltmc.enigma.command.CommonArguments.ENIGMA_PROFILE;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
+import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
+
 public final class InsertProposedMappingsCommand extends Command {
 	public static final InsertProposedMappingsCommand INSTANCE = new InsertProposedMappingsCommand();
 
 	private InsertProposedMappingsCommand() {
 		super(
-				ImmutableList.of(
-						CommonArguments.INPUT_JAR,
-						CommonArguments.INPUT_MAPPINGS,
-						CommonArguments.MAPPING_OUTPUT
-				),
-				ImmutableList.of(
-						CommonArguments.ENIGMA_PROFILE,
-						CommonArguments.OBFUSCATED_NAMESPACE,
-						CommonArguments.DEOBFUSCATED_NAMESPACE
-				)
+				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT),
+				ImmutableList.of(ENIGMA_PROFILE, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
 		);
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
-		Path inJar = getReadablePath(this.getArg(args, 0));
-		Path source = getReadablePath(this.getArg(args, 1));
-		Path output = getWritablePath(this.getArg(args, 2));
-		Path profilePath = getReadablePath(this.getArg(args, 3));
-		String obfuscatedNamespace = this.getArg(args, 4);
-		String deobfuscatedNamespace = this.getArg(args, 5);
-
-		run(inJar, source, output, profilePath, null, obfuscatedNamespace, deobfuscatedNamespace);
+	protected void runImpl(Map<String, String> args) throws Exception {
+		run(
+				getReadablePath(args.get(INPUT_JAR.getName())),
+				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
+				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
+				getReadablePath(args.get(ENIGMA_PROFILE.getName())),
+				null,
+				args.get(OBFUSCATED_NAMESPACE.getName()),
+				args.get(DEOBFUSCATED_NAMESPACE.getName())
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/InsertProposedMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/InsertProposedMappingsCommand.java
@@ -47,13 +47,9 @@ public final class InsertProposedMappingsCommand extends Command {
 	@Override
 	protected void runImpl(Map<String, String> args) throws Exception {
 		run(
-				getReadablePath(args.get(INPUT_JAR.getName())),
-				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
-				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
-				getReadablePath(args.get(ENIGMA_PROFILE.getName())),
-				null,
-				args.get(OBFUSCATED_NAMESPACE.getName()),
-				args.get(DEOBFUSCATED_NAMESPACE.getName())
+				INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
+				ENIGMA_PROFILE.get(args), null,
+				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
 		);
 	}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/InsertProposedMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/InsertProposedMappingsCommand.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.EnigmaProfile;
 import org.quiltmc.enigma.api.EnigmaProject;
@@ -20,6 +19,8 @@ import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntr
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.util.Utils;
 import org.quiltmc.enigma.util.validation.ValidationContext;
+import org.quiltmc.enigma.command.InsertProposedMappingsCommand.Required;
+import org.quiltmc.enigma.command.InsertProposedMappingsCommand.Optional;
 import org.tinylog.Logger;
 
 import java.nio.file.Path;
@@ -34,22 +35,22 @@ import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
-public final class InsertProposedMappingsCommand extends Command {
+public final class InsertProposedMappingsCommand extends Command<Required, Optional> {
 	public static final InsertProposedMappingsCommand INSTANCE = new InsertProposedMappingsCommand();
 
 	private InsertProposedMappingsCommand() {
 		super(
-				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT),
-				ImmutableList.of(ENIGMA_PROFILE, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
+				ArgsParser.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT, Required::new),
+				ArgsParser.of(ENIGMA_PROFILE, OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE, Optional::new)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
+	void runImpl(Required required, Optional optional) throws Exception {
 		run(
-				INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
-				ENIGMA_PROFILE.get(args), null,
-				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
+				required.inputJar, required.inputMappings, required.mappingOutput,
+				optional.enigmaProfile, null,
+				optional.obfuscatedNamespace, optional.deobfuscatedNamespace
 		);
 	}
 
@@ -142,6 +143,13 @@ public final class InsertProposedMappingsCommand extends Command {
 			}
 		});
 
-		Logger.info("Proposed names for {} classes, {} fields, {} methods, {} parameters!", classes, fields, methods, parameters);
+		Logger.info(
+				"Proposed names for {} classes, {} fields, {} methods, {} parameters!",
+				classes, fields, methods, parameters
+		);
 	}
+
+	record Required(Path inputJar, Path inputMappings, Path mappingOutput) { }
+
+	record Optional(Path enigmaProfile, String obfuscatedNamespace, String deobfuscatedNamespace) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
@@ -20,7 +20,7 @@ import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
 public final class InvertMappingsCommand extends Command {
-	private static final Argument OUTPUT_FOLDER = Argument.ofPath("output-folder",
+	private static final Argument<Path> OUTPUT_FOLDER = Argument.ofWritablePath("output-folder",
 			"""
 					A path to the file or folder to write output to."""
 	);
@@ -37,10 +37,10 @@ public final class InvertMappingsCommand extends Command {
 	@Override
 	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
 		run(
-				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
-				getWritablePath(args.get(OUTPUT_FOLDER.getName())),
-				args.get(OBFUSCATED_NAMESPACE.getName()),
-				args.get(DEOBFUSCATED_NAMESPACE.getName())
+				INPUT_MAPPINGS.get(args),
+				OUTPUT_FOLDER.get(args),
+				OBFUSCATED_NAMESPACE.get(args),
+				DEOBFUSCATED_NAMESPACE.get(args)
 		);
 	}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
@@ -17,19 +17,15 @@ import java.util.Map;
 
 import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
 public final class InvertMappingsCommand extends Command {
-	private static final Argument<Path> OUTPUT_FOLDER = Argument.ofWritablePath("output-folder",
-			"""
-					A path to the file or folder to write output to."""
-	);
-
 	public static final InvertMappingsCommand INSTANCE = new InvertMappingsCommand();
 
 	private InvertMappingsCommand() {
 		super(
-				ImmutableList.of(INPUT_MAPPINGS, OUTPUT_FOLDER),
+				ImmutableList.of(INPUT_MAPPINGS, MAPPING_OUTPUT),
 				ImmutableList.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
 		);
 	}
@@ -38,7 +34,7 @@ public final class InvertMappingsCommand extends Command {
 	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
 		run(
 				INPUT_MAPPINGS.get(args),
-				OUTPUT_FOLDER.get(args),
+				MAPPING_OUTPUT.get(args),
 				OBFUSCATED_NAMESPACE.get(args),
 				DEOBFUSCATED_NAMESPACE.get(args)
 		);

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
@@ -13,9 +13,14 @@ import org.quiltmc.enigma.util.Utils;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
+
+import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
 public final class InvertMappingsCommand extends Command {
-	private static final Argument OUTPUT_FOLDER = new Argument("<output-folder>",
+	private static final Argument OUTPUT_FOLDER = Argument.ofPath("output-folder",
 			"""
 					A path to the file or folder to write output to."""
 	);
@@ -24,19 +29,19 @@ public final class InvertMappingsCommand extends Command {
 
 	private InvertMappingsCommand() {
 		super(
-				ImmutableList.of(CommonArguments.INPUT_MAPPINGS, OUTPUT_FOLDER),
-				ImmutableList.of(CommonArguments.OBFUSCATED_NAMESPACE, CommonArguments.DEOBFUSCATED_NAMESPACE)
+				ImmutableList.of(INPUT_MAPPINGS, OUTPUT_FOLDER),
+				ImmutableList.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
 		);
 	}
 
 	@Override
-	public void run(String... args) throws IOException, MappingParseException {
-		Path source = getReadablePath(this.getArg(args, 0));
-		Path result = getWritablePath(this.getArg(args, 2));
-		String obfuscatedNamespace = this.getArg(args, 3);
-		String deobfuscatedNamespace = this.getArg(args, 4);
-
-		run(source, result, obfuscatedNamespace, deobfuscatedNamespace);
+	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
+		run(
+				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
+				getWritablePath(args.get(OUTPUT_FOLDER.getName())),
+				args.get(OBFUSCATED_NAMESPACE.getName()),
+				args.get(DEOBFUSCATED_NAMESPACE.getName())
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/InvertMappingsCommand.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.util.MappingOperations;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingParseException;
@@ -9,34 +8,33 @@ import org.quiltmc.enigma.api.translation.mapping.serde.MappingFileNameFormat;
 import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
 import org.quiltmc.enigma.util.Utils;
+import org.quiltmc.enigma.command.InvertMappingsCommand.Required;
+import org.quiltmc.enigma.command.InvertMappingsCommand.Optional;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Map;
 
 import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
-public final class InvertMappingsCommand extends Command {
+public final class InvertMappingsCommand extends Command<Required, Optional> {
 	public static final InvertMappingsCommand INSTANCE = new InvertMappingsCommand();
 
 	private InvertMappingsCommand() {
 		super(
-				ImmutableList.of(INPUT_MAPPINGS, MAPPING_OUTPUT),
-				ImmutableList.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
+				ArgsParser.of(INPUT_MAPPINGS, MAPPING_OUTPUT, Required::new),
+				ArgsParser.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE, Optional::new)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
+	void runImpl(Required required, Optional optional) throws IOException, MappingParseException {
 		run(
-				INPUT_MAPPINGS.get(args),
-				MAPPING_OUTPUT.get(args),
-				OBFUSCATED_NAMESPACE.get(args),
-				DEOBFUSCATED_NAMESPACE.get(args)
+				required.inputMappings, required.mappingOutput,
+				optional.obfuscatedNamespace, optional.deobfuscatedNamespace
 		);
 	}
 
@@ -63,4 +61,8 @@ public final class InvertMappingsCommand extends Command {
 		Utils.delete(resultFile);
 		writeService.write(result, resultFile, saveParameters);
 	}
+
+	record Required(Path inputMappings, Path mappingOutput) { }
+
+	record Optional(String obfuscatedNamespace, String deobfuscatedNamespace) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Main.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Main.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 public class Main {
-	private static final ImmutableMap<String, Command> COMMANDS = Stream
+	private static final ImmutableMap<String, Command<?, ?>> COMMANDS = Stream
 			.of(
 				DeobfuscateCommand.INSTANCE,
 				DecompileCommand.INSTANCE,
@@ -37,7 +37,7 @@ public class Main {
 
 			String command = args[0].toLowerCase(Locale.ROOT);
 
-			Command cmd = COMMANDS.get(command);
+			Command<?, ?> cmd = COMMANDS.get(command);
 			if (cmd == null) {
 				throw new IllegalArgumentException("Command not recognized: " + command);
 			}
@@ -65,7 +65,7 @@ public class Main {
 		}
 	}
 
-	public static ImmutableMap<String, Command> getCommands() {
+	public static ImmutableMap<String, Command<?, ?>> getCommands() {
 		return COMMANDS;
 	}
 
@@ -78,7 +78,7 @@ public class Main {
 				\tjava -cp enigma.jar org.quiltmc.enigma.command.CommandMain <command> <args>
 				\twhere <command> is one of:""");
 
-		for (Command command : COMMANDS.values()) {
+		for (Command<?, ?> command : COMMANDS.values()) {
 			command.appendHelp(help);
 		}
 	}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Main.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Main.java
@@ -75,7 +75,7 @@ public class Main {
 		StringBuilder help = new StringBuilder();
 		help.append("""
 				Usage:
-				\tjava -cp enigma.jar org.quiltmc.enigma.command.CommandMain <command> <args>
+				\tjava -jar enigma.jar <command> <args>
 				\twhere <command> is one of:""");
 
 		for (Command<?, ?> command : COMMANDS.values()) {

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Main.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Main.java
@@ -88,15 +88,15 @@ public class Main {
 	}
 
 	private static final class CommandErrorHelpException extends Command.HelpException {
-		final Command command;
+		final Command<?, ?> command;
 
-		CommandErrorHelpException(Command command, Throwable cause) {
+		CommandErrorHelpException(Command<?, ?> command, Throwable cause) {
 			super(cause);
 			this.command = command;
 		}
 
 		@Override
-		public Command getCommand() {
+		public Command<?, ?> getCommand() {
 			return this.command;
 		}
 	}

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/MapSpecializedMethodsCommand.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.analysis.index.jar.BridgeMethodIndex;
 import org.quiltmc.enigma.api.analysis.index.jar.JarIndex;
@@ -18,6 +17,8 @@ import org.quiltmc.enigma.api.translation.mapping.tree.EntryTreeNode;
 import org.quiltmc.enigma.api.translation.mapping.tree.HashEntryTree;
 import org.quiltmc.enigma.api.translation.representation.entry.MethodEntry;
 import org.quiltmc.enigma.util.Utils;
+import org.quiltmc.enigma.command.MapSpecializedMethodsCommand.Required;
+import org.quiltmc.enigma.command.MapSpecializedMethodsCommand.Optional;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -30,21 +31,21 @@ import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
 import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
 
-public final class MapSpecializedMethodsCommand extends Command {
+public final class MapSpecializedMethodsCommand extends Command<Required, Optional> {
 	public static final MapSpecializedMethodsCommand INSTANCE = new MapSpecializedMethodsCommand();
 
 	private MapSpecializedMethodsCommand() {
 		super(
-				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT),
-				ImmutableList.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
+				ArgsParser.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT, Required::new),
+				ArgsParser.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE, Optional::new)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
+	void runImpl(Required required, Optional optional) throws IOException, MappingParseException {
 		run(
-				INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
-				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
+				required.inputJar, required.inputMappings, required.mappingOutput,
+				optional.obfuscatedNamespace, optional.deobfuscatedNamespace
 		);
 	}
 
@@ -105,4 +106,8 @@ public final class MapSpecializedMethodsCommand extends Command {
 
 		return result;
 	}
+
+	record Required(Path inputJar, Path inputMappings, Path mappingOutput) { }
+
+	record Optional(String obfuscatedNamespace, String deobfuscatedNamespace) { }
 }

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/MapSpecializedMethodsCommand.java
@@ -24,25 +24,31 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 
+import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
+import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
+
 public final class MapSpecializedMethodsCommand extends Command {
 	public static final MapSpecializedMethodsCommand INSTANCE = new MapSpecializedMethodsCommand();
 
 	private MapSpecializedMethodsCommand() {
 		super(
-				ImmutableList.of(CommonArguments.INPUT_JAR, CommonArguments.INPUT_MAPPINGS, CommonArguments.MAPPING_OUTPUT),
-				ImmutableList.of(CommonArguments.OBFUSCATED_NAMESPACE, CommonArguments.DEOBFUSCATED_NAMESPACE)
+				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS, MAPPING_OUTPUT),
+				ImmutableList.of(OBFUSCATED_NAMESPACE, DEOBFUSCATED_NAMESPACE)
 		);
 	}
 
 	@Override
-	public void run(String... args) throws IOException, MappingParseException {
-		Path jar = getReadablePath(this.getArg(args, 0));
-		Path source = getReadablePath(this.getArg(args, 1));
-		Path result = getWritablePath(this.getArg(args, 2));
-		String obfuscatedNamespace = this.getArg(args, 3);
-		String deobfuscatedNamespace = this.getArg(args, 4);
-
-		run(jar, source, result, obfuscatedNamespace, deobfuscatedNamespace);
+	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
+		run(
+				getReadablePath(args.get(INPUT_JAR.getName())),
+				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
+				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
+				args.get(OBFUSCATED_NAMESPACE.getName()),
+				args.get(DEOBFUSCATED_NAMESPACE.getName())
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/MapSpecializedMethodsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/MapSpecializedMethodsCommand.java
@@ -43,11 +43,8 @@ public final class MapSpecializedMethodsCommand extends Command {
 	@Override
 	protected void runImpl(Map<String, String> args) throws IOException, MappingParseException {
 		run(
-				getReadablePath(args.get(INPUT_JAR.getName())),
-				getReadablePath(args.get(INPUT_MAPPINGS.getName())),
-				getWritablePath(args.get(MAPPING_OUTPUT.getName())),
-				args.get(OBFUSCATED_NAMESPACE.getName()),
-				args.get(DEOBFUSCATED_NAMESPACE.getName())
+				INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), MAPPING_OUTPUT.get(args),
+				OBFUSCATED_NAMESPACE.get(args), DEOBFUSCATED_NAMESPACE.get(args)
 		);
 	}
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.EnigmaPlugin;
 import org.quiltmc.enigma.api.EnigmaProfile;
@@ -8,30 +7,30 @@ import org.quiltmc.enigma.api.stats.GenerationParameters;
 import org.quiltmc.enigma.api.stats.ProjectStatsResult;
 import org.quiltmc.enigma.api.stats.StatType;
 import org.quiltmc.enigma.api.stats.StatsGenerator;
+import org.quiltmc.enigma.command.PrintStatsCommand.Required;
 import org.tinylog.Logger;
 
 import javax.annotation.Nullable;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Set;
 
 import static org.quiltmc.enigma.command.CommonArguments.ENIGMA_PROFILE;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 
-public final class PrintStatsCommand extends Command {
+public final class PrintStatsCommand extends Command<Required, Path> {
 	public static final PrintStatsCommand INSTANCE = new PrintStatsCommand();
 
 	private PrintStatsCommand() {
 		super(
-				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS),
-				ImmutableList.of(ENIGMA_PROFILE)
+				ArgsParser.of(INPUT_JAR, INPUT_MAPPINGS, Required::new),
+				ArgsParser.of(ENIGMA_PROFILE)
 		);
 	}
 
 	@Override
-	protected void runImpl(Map<String, String> args) throws Exception {
-		run(INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), ENIGMA_PROFILE.get(args), null);
+	void runImpl(Required required, Path enigmaProfile) throws Exception {
+		run(required.inputJar, required.inputMappings, enigmaProfile, null);
 	}
 
 	@Override
@@ -61,5 +60,7 @@ public final class PrintStatsCommand extends Command {
 		Logger.info(String.format("Methods: %.2f%% (%s / %s)", result.getPercentage(StatType.METHODS), result.getMapped(StatType.METHODS), result.getMappable(StatType.METHODS)));
 		Logger.info(String.format("Parameters: %.2f%% (%s / %s)", result.getPercentage(StatType.PARAMETERS), result.getMapped(StatType.PARAMETERS), result.getMappable(StatType.PARAMETERS)));
 	}
+
+	record Required(Path inputJar, Path inputMappings) { }
 }
 

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
@@ -12,25 +12,31 @@ import org.tinylog.Logger;
 
 import javax.annotation.Nullable;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Set;
+
+import static org.quiltmc.enigma.command.CommonArguments.ENIGMA_PROFILE;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 
 public final class PrintStatsCommand extends Command {
 	public static final PrintStatsCommand INSTANCE = new PrintStatsCommand();
 
 	private PrintStatsCommand() {
 		super(
-				ImmutableList.of(CommonArguments.INPUT_JAR, CommonArguments.INPUT_MAPPINGS),
-				ImmutableList.of(CommonArguments.ENIGMA_PROFILE)
+				ImmutableList.of(INPUT_JAR, INPUT_MAPPINGS),
+				ImmutableList.of(ENIGMA_PROFILE)
 		);
 	}
 
 	@Override
-	public void run(String... args) throws Exception {
-		Path inJar = getReadablePath(this.getArg(args, 0));
-		Path mappings = getReadablePath(this.getArg(args, 1));
-		Path profilePath = getReadablePath(this.getArg(args, 2));
-
-		run(inJar, mappings, profilePath, null);
+	protected void runImpl(Map<String, String> args) throws Exception {
+		run(
+				getReadablePath(args.get(INPUT_JAR.getName())),
+				getReadablePath(INPUT_MAPPINGS.getName()),
+				getReadablePath(ENIGMA_PROFILE.getName()),
+				null
+		);
 	}
 
 	@Override

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
@@ -31,12 +31,7 @@ public final class PrintStatsCommand extends Command {
 
 	@Override
 	protected void runImpl(Map<String, String> args) throws Exception {
-		run(
-				getReadablePath(args.get(INPUT_JAR.getName())),
-				getReadablePath(INPUT_MAPPINGS.getName()),
-				getReadablePath(ENIGMA_PROFILE.getName()),
-				null
-		);
+		run(INPUT_JAR.get(args), INPUT_MAPPINGS.get(args), ENIGMA_PROFILE.get(args), null);
 	}
 
 	@Override

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgMapTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgMapTest.java
@@ -1,0 +1,180 @@
+package org.quiltmc.enigma.command;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import static org.quiltmc.enigma.command.CommonArguments.DEOBFUSCATED_NAMESPACE;
+import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
+import static org.quiltmc.enigma.command.CommonArguments.MAPPING_OUTPUT;
+import static org.quiltmc.enigma.command.CommonArguments.OBFUSCATED_NAMESPACE;
+
+public class ArgMapTest {
+	private static final InvertMappingsCommand TEST_SUBJECT = InvertMappingsCommand.INSTANCE;
+
+	private static final Argument<?>
+			REQUIRED_1 = INPUT_MAPPINGS, REQUIRED_2 = MAPPING_OUTPUT,
+			OPTIONAL_1 = OBFUSCATED_NAMESPACE, OPTIONAL_2 = DEOBFUSCATED_NAMESPACE;
+
+	private static final String
+			REQUIRED_VALUE_1 = "required1",
+			REQUIRED_VALUE_2 = "required2",
+			OPTIONAL_VALUE_1 = "optional1",
+			OPTIONAL_VALUE_2 = "optional2";
+
+	private static final ImmutableMap<String, String> COMPLETE_EXPECTED_MAP = ImmutableMap.of(
+			REQUIRED_1.getName(), REQUIRED_VALUE_1,
+			REQUIRED_2.getName(), REQUIRED_VALUE_2,
+			OPTIONAL_1.getName(), OPTIONAL_VALUE_1,
+			OPTIONAL_2.getName(), OPTIONAL_VALUE_2
+	);
+
+	private static final Collector<Argument<?>, ?, Map<String, String>> EXPECTATION_COLLECTOR = Collectors.toMap(
+		Argument::getName,
+		arg -> {
+			final String expectedValue = COMPLETE_EXPECTED_MAP.get(arg.getName());
+			assertNotNull(expectedValue);
+			return expectedValue;
+		}
+	);
+
+	@ParameterizedTest
+	@MethodSource("streamHomogenousArgsInputs")
+	void testAllUnnamedArgs(List<Argument<?>> arguments) {
+		assertHomogenousArgs(arguments, ArgMapTest::getUnnamedValue);
+	}
+
+	@ParameterizedTest
+	@MethodSource("streamHomogenousArgsInputs")
+	void testAllNamedArgs(List<Argument<?>> arguments) {
+		assertHomogenousArgs(arguments, ArgMapTest::getNamedValue);
+
+		final List<Argument<?>> reversed = reversed(arguments);
+		assertHomogenousArgs(reversed, ArgMapTest::getNamedValue);
+	}
+
+	@ParameterizedTest
+	@MethodSource("streamMixedInputs")
+	void testMixedArgs(MixedArgs arguments) {
+		final Map<String, String> expectation = Stream
+				.concat(arguments.unnamed.stream(), arguments.named.stream())
+				.collect(EXPECTATION_COLLECTOR);
+
+		final List<String> unnamedValues = arguments.unnamed.stream().map(ArgMapTest::getUnnamedValue).toList();
+
+		final String[] values1 = Stream
+				.concat(
+					unnamedValues.stream(),
+					arguments.named.stream().map(ArgMapTest::getNamedValue)
+				)
+				.toArray(String[]::new);
+
+		final List<Argument<?>> reversedNamed = reversed(arguments.named);
+		assertEquals(expectation, TEST_SUBJECT.buildValuesByName(values1));
+
+		final String[] values2 = Stream
+			.concat(
+				unnamedValues.stream(),
+				reversedNamed.stream().map(ArgMapTest::getNamedValue)
+			)
+			.toArray(String[]::new);
+
+		assertEquals(expectation, TEST_SUBJECT.buildValuesByName(values2));
+	}
+
+	private static Stream<MixedArgs> streamMixedInputs() {
+		return Stream.of(
+			MixedArgs.builder().unnamed(REQUIRED_1).named(REQUIRED_2).build(),
+			MixedArgs.builder().unnamed(REQUIRED_1).named(REQUIRED_2, OPTIONAL_1).build(),
+			MixedArgs.builder().unnamed(REQUIRED_1).named(REQUIRED_2, OPTIONAL_1, OPTIONAL_2).build(),
+			MixedArgs.builder().unnamed(REQUIRED_1, REQUIRED_2).named(OPTIONAL_1).build(),
+			MixedArgs.builder().unnamed(REQUIRED_1, REQUIRED_2).named(OPTIONAL_1, OPTIONAL_2).build(),
+			MixedArgs.builder().unnamed(REQUIRED_1, REQUIRED_2, OPTIONAL_1).named(OPTIONAL_2).build()
+		);
+	}
+
+	private static Stream<List<Argument<?>>> streamHomogenousArgsInputs() {
+		return Stream.of(
+			List.of(REQUIRED_1, REQUIRED_2),
+			List.of(REQUIRED_1, REQUIRED_2, OPTIONAL_1),
+			List.of(REQUIRED_1, REQUIRED_2, OPTIONAL_1, OPTIONAL_2)
+		);
+	}
+
+	@Test
+	void testInvalidArgs() {
+		//TODO
+	}
+
+	private static void assertHomogenousArgs(Collection<Argument<?>> args, Function<Argument<?>, String> valueGetter) {
+		final Map<String, String> expectation = args.stream().collect(EXPECTATION_COLLECTOR);
+
+		final String[] values = args.stream().map(valueGetter).toArray(String[]::new);
+		assertEquals(expectation, TEST_SUBJECT.buildValuesByName(values));
+	}
+
+	private static String getUnnamedValue(Argument<?> argument) {
+		final String value = COMPLETE_EXPECTED_MAP.get(argument.getName());
+		assertNotNull(value);
+		return value;
+	}
+
+	private static String getNamedValue(Argument<?> argument) {
+		return argument.getName() + Argument.NAME_DELIM + getUnnamedValue(argument);
+	}
+
+	private static <T> List<T> reversed(Collection<T> arguments) {
+		final List<T> reversed = new ArrayList<>(arguments);
+		Collections.reverse(reversed);
+		return reversed;
+	}
+
+	record MixedArgs(ImmutableList<Argument<?>> unnamed, ImmutableList<Argument<?>> named) {
+		static Builder builder() {
+			return new Builder();
+		}
+
+		static class Builder {
+			ImmutableList<Argument<?>> unnamed;
+			ImmutableList<Argument<?>> named;
+
+			Builder unnamed(Argument<?>... unnamed) {
+				this.unnamed = ImmutableList.copyOf(unnamed);
+				return this;
+			}
+
+			Builder named(Argument<?>... named) {
+				this.named = ImmutableList.copyOf(named);
+				return this;
+			}
+
+			MixedArgs build() {
+				if (this.unnamed == null || this.unnamed.isEmpty()) {
+					throw new IllegalStateException("Missing unnamed args.");
+				}
+
+				if (this.named == null || this.named.isEmpty()) {
+					throw new IllegalStateException("Missing named args.");
+				}
+
+				return new MixedArgs(Objects.requireNonNull(this.unnamed), Objects.requireNonNull(this.named));
+			}
+		}
+	}
+}

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgMapTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgMapTest.java
@@ -46,11 +46,7 @@ public class ArgMapTest {
 
 	private static final Collector<Argument<?>, ?, Map<String, String>> EXPECTATION_COLLECTOR = Collectors.toMap(
 			Argument::getName,
-			arg -> {
-				final String expectedValue = COMPLETE_EXPECTED_MAP.get(arg.getName());
-				assertNotNull(expectedValue);
-				return expectedValue;
-			}
+			ArgMapTest::getUnnamedValue
 	);
 
 	@ParameterizedTest
@@ -120,12 +116,12 @@ public class ArgMapTest {
 
 	private static Stream<MixedArgs> streamMixedInputs() {
 		return Stream.of(
-			MixedArgs.builder().unnamed(REQUIRED_1).named(REQUIRED_2).build(),
-			MixedArgs.builder().unnamed(REQUIRED_1).named(REQUIRED_2, OPTIONAL_1).build(),
-			MixedArgs.builder().unnamed(REQUIRED_1).named(REQUIRED_2, OPTIONAL_1, OPTIONAL_2).build(),
-			MixedArgs.builder().unnamed(REQUIRED_1, REQUIRED_2).named(OPTIONAL_1).build(),
-			MixedArgs.builder().unnamed(REQUIRED_1, REQUIRED_2).named(OPTIONAL_1, OPTIONAL_2).build(),
-			MixedArgs.builder().unnamed(REQUIRED_1, REQUIRED_2, OPTIONAL_1).named(OPTIONAL_2).build()
+			mixedBuilder().unnamed(REQUIRED_1).named(REQUIRED_2).build(),
+			mixedBuilder().unnamed(REQUIRED_1).named(REQUIRED_2, OPTIONAL_1).build(),
+			mixedBuilder().unnamed(REQUIRED_1).named(REQUIRED_2, OPTIONAL_1, OPTIONAL_2).build(),
+			mixedBuilder().unnamed(REQUIRED_1, REQUIRED_2).named(OPTIONAL_1).build(),
+			mixedBuilder().unnamed(REQUIRED_1, REQUIRED_2).named(OPTIONAL_1, OPTIONAL_2).build(),
+			mixedBuilder().unnamed(REQUIRED_1, REQUIRED_2, OPTIONAL_1).named(OPTIONAL_2).build()
 		);
 	}
 
@@ -189,7 +185,7 @@ public class ArgMapTest {
 
 	private static String getUnnamedValue(Argument<?> argument) {
 		final String value = COMPLETE_EXPECTED_MAP.get(argument.getName());
-		assertNotNull(value);
+		assertNotNull(value, () -> "No argument with name '" + argument.getName() + "' in COMPLETE_EXPECTED_MAP.");
 		return value;
 	}
 
@@ -201,6 +197,10 @@ public class ArgMapTest {
 		final List<T> reversed = new ArrayList<>(arguments);
 		Collections.reverse(reversed);
 		return reversed;
+	}
+
+	private static MixedArgs.Builder mixedBuilder() {
+		return MixedArgs.builder();
 	}
 
 	record MixedArgs(ImmutableList<Argument<?>> unnamed, ImmutableList<Argument<?>> named) {

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgsParserTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgsParserTest.java
@@ -19,10 +19,6 @@ public class ArgsParserTest {
 			NAME_9 = "name9", VALUE_9 = "value9",
 			NAME_10 = "name10", VALUE_10 = "value10";
 
-	private static final ImmutableList<String> ORDERED_NAMES = ImmutableList.of(
-			NAME_1, NAME_2, NAME_3, NAME_4, NAME_5, NAME_6, NAME_7, NAME_8, NAME_9, NAME_10
-	);
-
 	private static final Argument<String>
 			ARGUMENT_1 = Argument.ofString(NAME_1, "string", "test arg 1"),
 			ARGUMENT_2 = Argument.ofString(NAME_2, "string", "test arg 2"),
@@ -48,12 +44,15 @@ public class ArgsParserTest {
 			NAME_10, VALUE_10
 	);
 
+	private static final ImmutableList<String> ORDERED_NAMES = VALUES_BY_NAME.keySet().asList();
+	private static final ImmutableList<String> ORDERED_VALUES = VALUES_BY_NAME.values().asList();
+
 	@Test
 	void test1() {
 		final ArgsParser<String> parser = ArgsParser.of(ARGUMENT_1);
 		assertOrder(parser);
 		final String value = parseValues(parser);
-		assertEquals(value, VALUE_1);
+		assertValues(value);
 	}
 
 	@Test
@@ -61,8 +60,7 @@ public class ArgsParserTest {
 		final ArgsParser<Packed2> parser = ArgsParser.of(ARGUMENT_1, ARGUMENT_2, Packed2::new);
 		assertOrder(parser);
 		final Packed2 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
+		assertValues(packed.arg1, packed.arg2);
 	}
 
 	@Test
@@ -70,9 +68,7 @@ public class ArgsParserTest {
 		final ArgsParser<Packed3> parser = ArgsParser.of(ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, Packed3::new);
 		assertOrder(parser);
 		final Packed3 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
+		assertValues(packed.arg1, packed.arg2, packed.arg3);
 	}
 
 	@Test
@@ -80,10 +76,7 @@ public class ArgsParserTest {
 		final ArgsParser<Packed4> parser = ArgsParser.of(ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, Packed4::new);
 		assertOrder(parser);
 		final Packed4 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
-		assertEquals(packed.arg4, VALUE_4);
+		assertValues(packed.arg1, packed.arg2, packed.arg3, packed.arg4);
 	}
 
 	@Test
@@ -94,11 +87,7 @@ public class ArgsParserTest {
 		);
 		assertOrder(parser);
 		final Packed5 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
-		assertEquals(packed.arg4, VALUE_4);
-		assertEquals(packed.arg5, VALUE_5);
+		assertValues(packed.arg1, packed.arg2, packed.arg3, packed.arg4, packed.arg5);
 	}
 
 	@Test
@@ -109,12 +98,7 @@ public class ArgsParserTest {
 		);
 		assertOrder(parser);
 		final Packed6 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
-		assertEquals(packed.arg4, VALUE_4);
-		assertEquals(packed.arg5, VALUE_5);
-		assertEquals(packed.arg6, VALUE_6);
+		assertValues(packed.arg1, packed.arg2, packed.arg3, packed.arg4, packed.arg5, packed.arg6);
 	}
 
 	@Test
@@ -125,13 +109,7 @@ public class ArgsParserTest {
 		);
 		assertOrder(parser);
 		final Packed7 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
-		assertEquals(packed.arg4, VALUE_4);
-		assertEquals(packed.arg5, VALUE_5);
-		assertEquals(packed.arg6, VALUE_6);
-		assertEquals(packed.arg7, VALUE_7);
+		assertValues(packed.arg1, packed.arg2, packed.arg3, packed.arg4, packed.arg5, packed.arg6, packed.arg7);
 	}
 
 	@Test
@@ -142,14 +120,9 @@ public class ArgsParserTest {
 		);
 		assertOrder(parser);
 		final Packed8 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
-		assertEquals(packed.arg4, VALUE_4);
-		assertEquals(packed.arg5, VALUE_5);
-		assertEquals(packed.arg6, VALUE_6);
-		assertEquals(packed.arg7, VALUE_7);
-		assertEquals(packed.arg8, VALUE_8);
+		assertValues(
+				packed.arg1, packed.arg2, packed.arg3, packed.arg4, packed.arg5, packed.arg6, packed.arg7, packed.arg8
+		);
 	}
 
 	@Test
@@ -161,15 +134,10 @@ public class ArgsParserTest {
 		);
 		assertOrder(parser);
 		final Packed9 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
-		assertEquals(packed.arg4, VALUE_4);
-		assertEquals(packed.arg5, VALUE_5);
-		assertEquals(packed.arg6, VALUE_6);
-		assertEquals(packed.arg7, VALUE_7);
-		assertEquals(packed.arg8, VALUE_8);
-		assertEquals(packed.arg9, VALUE_9);
+		assertValues(
+				packed.arg1, packed.arg2, packed.arg3, packed.arg4, packed.arg5,
+				packed.arg6, packed.arg7, packed.arg8, packed.arg9
+		);
 	}
 
 	@Test
@@ -181,21 +149,21 @@ public class ArgsParserTest {
 		);
 		assertOrder(parser);
 		final Packed10 packed = parseValues(parser);
-		assertEquals(packed.arg1, VALUE_1);
-		assertEquals(packed.arg2, VALUE_2);
-		assertEquals(packed.arg3, VALUE_3);
-		assertEquals(packed.arg4, VALUE_4);
-		assertEquals(packed.arg5, VALUE_5);
-		assertEquals(packed.arg6, VALUE_6);
-		assertEquals(packed.arg7, VALUE_7);
-		assertEquals(packed.arg8, VALUE_8);
-		assertEquals(packed.arg9, VALUE_9);
-		assertEquals(packed.arg10, VALUE_10);
+		assertValues(
+				packed.arg1, packed.arg2, packed.arg3, packed.arg4, packed.arg5,
+				packed.arg6, packed.arg7, packed.arg8, packed.arg9, packed.arg10
+		);
 	}
 
 	private static void assertOrder(ArgsParser<?> parser) {
 		for (int i = 0; i < parser.count(); i++) {
 			assertEquals(parser.get(i).getName(), ORDERED_NAMES.get(i));
+		}
+	}
+
+	private static void assertValues(String... values) {
+		for (int i = 0; i < values.length; i++) {
+			assertEquals(values[i], ORDERED_VALUES.get(i));
 		}
 	}
 

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgsParserTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ArgsParserTest.java
@@ -1,0 +1,225 @@
+package org.quiltmc.enigma.command;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ArgsParserTest {
+	private static final String
+			NAME_1 = "name1", VALUE_1 = "value1",
+			NAME_2 = "name2", VALUE_2 = "value2",
+			NAME_3 = "name3", VALUE_3 = "value3",
+			NAME_4 = "name4", VALUE_4 = "value4",
+			NAME_5 = "name5", VALUE_5 = "value5",
+			NAME_6 = "name6", VALUE_6 = "value6",
+			NAME_7 = "name7", VALUE_7 = "value7",
+			NAME_8 = "name8", VALUE_8 = "value8",
+			NAME_9 = "name9", VALUE_9 = "value9",
+			NAME_10 = "name10", VALUE_10 = "value10";
+
+	private static final ImmutableList<String> ORDERED_NAMES = ImmutableList.of(
+			NAME_1, NAME_2, NAME_3, NAME_4, NAME_5, NAME_6, NAME_7, NAME_8, NAME_9, NAME_10
+	);
+
+	private static final Argument<String>
+			ARGUMENT_1 = Argument.ofString(NAME_1, "string", "test arg 1"),
+			ARGUMENT_2 = Argument.ofString(NAME_2, "string", "test arg 2"),
+			ARGUMENT_3 = Argument.ofString(NAME_3, "string", "test arg 3"),
+			ARGUMENT_4 = Argument.ofString(NAME_4, "string", "test arg 4"),
+			ARGUMENT_5 = Argument.ofString(NAME_5, "string", "test arg 5"),
+			ARGUMENT_6 = Argument.ofString(NAME_6, "string", "test arg 6"),
+			ARGUMENT_7 = Argument.ofString(NAME_7, "string", "test arg 7"),
+			ARGUMENT_8 = Argument.ofString(NAME_8, "string", "test arg 8"),
+			ARGUMENT_9 = Argument.ofString(NAME_9, "string", "test arg 9"),
+			ARGUMENT_10 = Argument.ofString(NAME_10, "string", "test arg 10");
+
+	private static final ImmutableMap<String, String> VALUES_BY_NAME = ImmutableMap.of(
+			NAME_1, VALUE_1,
+			NAME_2, VALUE_2,
+			NAME_3, VALUE_3,
+			NAME_4, VALUE_4,
+			NAME_5, VALUE_5,
+			NAME_6, VALUE_6,
+			NAME_7, VALUE_7,
+			NAME_8, VALUE_8,
+			NAME_9, VALUE_9,
+			NAME_10, VALUE_10
+	);
+
+	@Test
+	void test1() {
+		final ArgsParser<String> parser = ArgsParser.of(ARGUMENT_1);
+		assertOrder(parser);
+		final String value = parseValues(parser);
+		assertEquals(value, VALUE_1);
+	}
+
+	@Test
+	void test2() {
+		final ArgsParser<Packed2> parser = ArgsParser.of(ARGUMENT_1, ARGUMENT_2, Packed2::new);
+		assertOrder(parser);
+		final Packed2 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+	}
+
+	@Test
+	void test3() {
+		final ArgsParser<Packed3> parser = ArgsParser.of(ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, Packed3::new);
+		assertOrder(parser);
+		final Packed3 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+	}
+
+	@Test
+	void test4() {
+		final ArgsParser<Packed4> parser = ArgsParser.of(ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, Packed4::new);
+		assertOrder(parser);
+		final Packed4 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+		assertEquals(packed.arg4, VALUE_4);
+	}
+
+	@Test
+	void test5() {
+		final ArgsParser<Packed5> parser = ArgsParser.of(
+				ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, ARGUMENT_5,
+				Packed5::new
+		);
+		assertOrder(parser);
+		final Packed5 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+		assertEquals(packed.arg4, VALUE_4);
+		assertEquals(packed.arg5, VALUE_5);
+	}
+
+	@Test
+	void test6() {
+		final ArgsParser<Packed6> parser = ArgsParser.of(
+				ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, ARGUMENT_5, ARGUMENT_6,
+				Packed6::new
+		);
+		assertOrder(parser);
+		final Packed6 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+		assertEquals(packed.arg4, VALUE_4);
+		assertEquals(packed.arg5, VALUE_5);
+		assertEquals(packed.arg6, VALUE_6);
+	}
+
+	@Test
+	void test7() {
+		final ArgsParser<Packed7> parser = ArgsParser.of(
+				ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, ARGUMENT_5, ARGUMENT_6, ARGUMENT_7,
+				Packed7::new
+		);
+		assertOrder(parser);
+		final Packed7 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+		assertEquals(packed.arg4, VALUE_4);
+		assertEquals(packed.arg5, VALUE_5);
+		assertEquals(packed.arg6, VALUE_6);
+		assertEquals(packed.arg7, VALUE_7);
+	}
+
+	@Test
+	void test8() {
+		final ArgsParser<Packed8> parser = ArgsParser.of(
+				ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, ARGUMENT_5, ARGUMENT_6, ARGUMENT_7, ARGUMENT_8,
+				Packed8::new
+		);
+		assertOrder(parser);
+		final Packed8 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+		assertEquals(packed.arg4, VALUE_4);
+		assertEquals(packed.arg5, VALUE_5);
+		assertEquals(packed.arg6, VALUE_6);
+		assertEquals(packed.arg7, VALUE_7);
+		assertEquals(packed.arg8, VALUE_8);
+	}
+
+	@Test
+	void test9() {
+		final ArgsParser<Packed9> parser = ArgsParser.of(
+				ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, ARGUMENT_5,
+				ARGUMENT_6, ARGUMENT_7, ARGUMENT_8, ARGUMENT_9,
+				Packed9::new
+		);
+		assertOrder(parser);
+		final Packed9 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+		assertEquals(packed.arg4, VALUE_4);
+		assertEquals(packed.arg5, VALUE_5);
+		assertEquals(packed.arg6, VALUE_6);
+		assertEquals(packed.arg7, VALUE_7);
+		assertEquals(packed.arg8, VALUE_8);
+		assertEquals(packed.arg9, VALUE_9);
+	}
+
+	@Test
+	void test10() {
+		final ArgsParser<Packed10> parser = ArgsParser.of(
+				ARGUMENT_1, ARGUMENT_2, ARGUMENT_3, ARGUMENT_4, ARGUMENT_5,
+				ARGUMENT_6, ARGUMENT_7, ARGUMENT_8, ARGUMENT_9, ARGUMENT_10,
+				Packed10::new
+		);
+		assertOrder(parser);
+		final Packed10 packed = parseValues(parser);
+		assertEquals(packed.arg1, VALUE_1);
+		assertEquals(packed.arg2, VALUE_2);
+		assertEquals(packed.arg3, VALUE_3);
+		assertEquals(packed.arg4, VALUE_4);
+		assertEquals(packed.arg5, VALUE_5);
+		assertEquals(packed.arg6, VALUE_6);
+		assertEquals(packed.arg7, VALUE_7);
+		assertEquals(packed.arg8, VALUE_8);
+		assertEquals(packed.arg9, VALUE_9);
+		assertEquals(packed.arg10, VALUE_10);
+	}
+
+	private static void assertOrder(ArgsParser<?> parser) {
+		for (int i = 0; i < parser.count(); i++) {
+			assertEquals(parser.get(i).getName(), ORDERED_NAMES.get(i));
+		}
+	}
+
+	private static <T> T parseValues(ArgsParser<T> parser) {
+		return parser.parse(VALUES_BY_NAME, Argument::from);
+	}
+
+	private record Packed2(String arg1, String arg2) { }
+	private record Packed3(String arg1, String arg2, String arg3) { }
+	private record Packed4(String arg1, String arg2, String arg3, String arg4) { }
+	private record Packed5(String arg1, String arg2, String arg3, String arg4, String arg5) { }
+	private record Packed6(String arg1, String arg2, String arg3, String arg4, String arg5, String arg6) { }
+	private record Packed7(
+			String arg1, String arg2, String arg3, String arg4, String arg5, String arg6, String arg7
+	) { }
+	private record Packed8(
+			String arg1, String arg2, String arg3, String arg4, String arg5, String arg6, String arg7, String arg8
+	) { }
+	private record Packed9(
+			String arg1, String arg2, String arg3, String arg4, String arg5,
+			String arg6, String arg7, String arg8, String arg9
+	) { }
+	private record Packed10(
+			String arg1, String arg2, String arg3, String arg4, String arg5,
+			String arg6, String arg7, String arg8, String arg9, String arg10
+	) { }
+}

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
@@ -33,15 +33,8 @@ public class ValidateArgNamesTest {
 			for (int i = 0; i < argName.length(); i++) {
 				final char c = argName.charAt(i);
 
-				Assertions.assertNotEquals(
-						Argument.SEPARATOR, c,
-						() -> getIllegalCharacterMessage(cmdName, argName, Argument.SEPARATOR)
-				);
-
-				Assertions.assertNotEquals(
-						Argument.NAME_DELIM, c,
-						() -> getIllegalCharacterMessage(cmdName, argName, Argument.NAME_DELIM)
-				);
+				assertLegal(cmdName, argName, Argument.SEPARATOR, c);
+				assertLegal(cmdName, argName, Argument.NAME_DELIM, c);
 			}
 
 			Assertions.assertTrue(
@@ -53,8 +46,11 @@ public class ValidateArgNamesTest {
 		return argNames;
 	}
 
-	private static String getIllegalCharacterMessage(String cmdName, String argName, char illegal) {
-		return "Command '%s' arg '%s' name must not contain '%s'".formatted(cmdName, argName, illegal);
+	private static void assertLegal(String cmdName, String argName, char illegal, char actual) {
+		Assertions.assertNotEquals(
+				illegal, actual,
+				() -> "Command '%s' arg '%s' name must not contain '%s'".formatted(cmdName, argName, illegal)
+		);
 	}
 
 	private static String getDuplicateNameMessage(String cmdName, String argName) {

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
@@ -1,0 +1,63 @@
+package org.quiltmc.enigma.command;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ValidateArgNamesTest {
+	@Test
+	void validate() {
+		Main.getCommands().forEach((cmdName, cmd) -> {
+			final Set<String> requiredNames = validateArgs(cmdName, cmd.requiredArguments);
+			final Set<String> optionalNames = validateArgs(cmdName, cmd.optionalArguments);
+			requiredNames.forEach(required -> Assertions.assertFalse(
+					optionalNames.contains(required),
+					() -> getDuplicateNameMessage(cmdName, required)
+			));
+		});
+	}
+
+	private static Set<String> validateArgs(String cmdName, ImmutableList<Argument> args) {
+		final Set<String> argNames = new HashSet<>();
+		for (final Argument arg : args) {
+			final String argName = arg.getName();
+
+			Assertions.assertFalse(
+					argName.isEmpty(),
+					() -> "Command '%s' arg '%s' name must not be empty".formatted(cmdName, arg)
+			);
+
+			for (int i = 0; i < argName.length(); i++) {
+				final char c = argName.charAt(i);
+
+				Assertions.assertNotEquals(
+						Argument.SEPARATOR, c,
+						() -> getIllegalCharacterMessage(cmdName, argName, Argument.SEPARATOR)
+				);
+
+				Assertions.assertNotEquals(
+						Argument.NAME_DELIM, c,
+						() -> getIllegalCharacterMessage(cmdName, argName, Argument.NAME_DELIM)
+				);
+			}
+
+			Assertions.assertTrue(
+					argNames.add(argName),
+					() -> getDuplicateNameMessage(cmdName, argName)
+			);
+		}
+
+		return argNames;
+	}
+
+	private static String getIllegalCharacterMessage(String cmdName, String argName, char illegal) {
+		return "Command '%s' arg '%s' name must not contain '%s'".formatted(cmdName, argName, illegal);
+	}
+
+	private static String getDuplicateNameMessage(String cmdName, String argName) {
+		return "Command '%s' duplicates argument name '%s'".formatted(cmdName, argName);
+	}
+}

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
@@ -22,7 +22,7 @@ public class ValidateArgNamesTest {
 
 	private static Set<String> validateArgs(String cmdName, ImmutableList<Argument<?>> args) {
 		final Set<String> argNames = new HashSet<>();
-		for (final Argument arg : args) {
+		for (final Argument<?> arg : args) {
 			final String argName = arg.getName();
 
 			Assertions.assertFalse(

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
@@ -20,7 +20,7 @@ public class ValidateArgNamesTest {
 		});
 	}
 
-	private static Set<String> validateArgs(String cmdName, ImmutableList<Argument> args) {
+	private static Set<String> validateArgs(String cmdName, ImmutableList<Argument<?>> args) {
 		final Set<String> argNames = new HashSet<>();
 		for (final Argument arg : args) {
 			final String argName = arg.getName();

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/ValidateArgNamesTest.java
@@ -1,6 +1,5 @@
 package org.quiltmc.enigma.command;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +19,7 @@ public class ValidateArgNamesTest {
 		});
 	}
 
-	private static Set<String> validateArgs(String cmdName, ImmutableList<Argument<?>> args) {
+	private static Set<String> validateArgs(String cmdName, ArgsParser<?> args) {
 		final Set<String> argNames = new HashSet<>();
 		for (final Argument<?> arg : args) {
 			final String argName = arg.getName();

--- a/enigma/src/main/java/org/quiltmc/enigma/util/Utils.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/util/Utils.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -99,5 +100,52 @@ public class Utils {
 		} finally {
 			l.unlock();
 		}
+	}
+
+	public static String andJoin(String... words) {
+		return andJoin(true, words);
+	}
+
+	public static String andJoin(boolean oxfordComma, String... words) {
+		return andJoin(oxfordComma, Arrays.asList(words));
+	}
+
+	public static String andJoin(List<String> words) {
+		return andJoin(true, words);
+	}
+
+	public static String andJoin(boolean oxfordComma, List<String> words) {
+		return naturalJoin(" and ", oxfordComma, words);
+	}
+
+	/**
+	 * @param finalSeparator the separator used between the last two {@code words}
+	 * @param oxfordComma whether to include a comma before the {@code finalSeparator}
+	 * 						in cases of three or more {@code words}
+	 * @param words the words to join
+	 * @return the passed {@code words} joined as an english language list
+	 */
+	public static String naturalJoin(String finalSeparator, boolean oxfordComma, List<String> words) {
+		final int count = words.size();
+		return switch (count) {
+			case 0 -> "";
+			case 1 -> words.get(0);
+			case 2 -> words.get(0) + finalSeparator + words.get(1);
+			default -> {
+				final StringBuilder joined = new StringBuilder(words.get(0));
+				final int lastIndex = count - 1;
+				for (final String word : words.subList(1, lastIndex)) {
+					joined.append(", ").append(word);
+				}
+
+				if (oxfordComma) {
+					joined.append(",");
+				}
+
+				joined.append(finalSeparator).append(words.get(lastIndex));
+
+				yield joined.toString();
+			}
+		};
 	}
 }


### PR DESCRIPTION
~~based on #277~~ rebased

Allows use of named args of the form `some-name=some-value`.
Particularly useful for commands with many optional args.

Unnamed positional arguments may still be used, even at the same time as named args, so long as all positional args come before named args.

Centralizes parsing of individual args into `Argument` and of commands' accepted args into `ArgsParser`.

Additionally, makes path verification more consistent and fixes the following bugs:
- **breaking**: `InvertMappingsCommand` used `OUTPUT_FOLDER` instead of `MAPPING_OUTPUT`
- `InvertMappingsCommand` args skipped an index
- `DecompileCommand` used `getWritableFolder` for `OUTPUT_JAR`
- users of `ENIGMA_PROFILE` didn't verify it was a file
- `ComposeMappingsCommand` didn't declare its optional de/obf args