### PR TITLE
use enigma variable

### DIFF
--- a/enigma-server/src/main/java/org/quiltmc/enigma/network/DedicatedEnigmaServer.java
+++ b/enigma-server/src/main/java/org/quiltmc/enigma/network/DedicatedEnigmaServer.java
@@ -124,10 +124,10 @@ public class DedicatedEnigmaServer extends EnigmaServer {
 
 			EntryRemapper mappings;
 			if (!Files.exists(mappingsFile)) {
-				mappings = EntryRemapper.mapped(project.getEnigma(), project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), new HashEntryTree<>(), enigma.getNameProposalServices());
+				mappings = EntryRemapper.mapped(enigma, project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), new HashEntryTree<>(), enigma.getNameProposalServices());
 			} else {
 				Logger.info("Reading mappings...");
-				mappings = EntryRemapper.mapped(project.getEnigma(), project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), readWriteService.get().read(mappingsFile), enigma.getNameProposalServices());
+				mappings = EntryRemapper.mapped(enigma, project.getJarIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), readWriteService.get().read(mappingsFile), enigma.getNameProposalServices());
 			}
 
 			PrintWriter log = new PrintWriter(Files.newBufferedWriter(logFile));


### PR DESCRIPTION
consistently use enigma variable in `DedicatedEnigmaServer`

no effect as they're the same instance, but makes it easier to tell that only one instance is used