### PR TITLE
replace DecompileCommand's OUTPUT_JAR arg with new OUTPUT_DIR arg

### DIFF
--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/Argument.java
@@ -35,6 +35,18 @@ final class Argument<T> {
 	static final String BOOL_TYPE = true + ALTERNATIVES_DELIM + false;
 	static final String PATH_TYPE = "path";
 
+	static Argument<Path> ofPath(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, string -> getPath(string).orElse(null), explanation);
+	}
+
+	static Argument<Path> ofFile(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getFile, explanation);
+	}
+
+	static Argument<Path> ofFolder(String name, String explanation) {
+		return new Argument<>(name, PATH_TYPE, Argument::getFolder, explanation);
+	}
+
 	static Argument<Path> ofReadablePath(String name, String explanation) {
 		return new Argument<>(name, PATH_TYPE, Argument::getReadablePath, explanation);
 	}
@@ -99,6 +111,14 @@ final class Argument<T> {
 		this.explanation = explanation;
 	}
 
+	static Path getFile(String path) {
+		return verifyFile(getPath(path)).orElse(null);
+	}
+
+	static Path getFolder(String path) {
+		return verifyFolder(getPath(path)).orElse(null);
+	}
+
 	static Path getReadablePath(String path) {
 		return getExistentPath(path).orElse(null);
 	}
@@ -116,8 +136,7 @@ final class Argument<T> {
 	}
 
 	static Path getWritableFile(String path) {
-		// !directory so it's true for non-existent files
-		return verify(getParentedPath(path), p -> !Files.isDirectory(p), "Not a file: ").orElse(null);
+		return verifyFile(getParentedPath(path)).orElse(null);
 	}
 
 	static Path getWritableFolder(String path) {
@@ -152,6 +171,18 @@ final class Argument<T> {
 			.filter(string -> !string.isEmpty())
 			.map(Paths::get)
 			.map(Path::toAbsolutePath);
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	static Optional<Path> verifyFile(Optional<Path> path) {
+		// !directory so it's true for non-existent files
+		return verify(path, p -> !Files.isDirectory(p), "Not a file: ");
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	static Optional<Path> verifyFolder(Optional<Path> path) {
+		// !directory so it's true for non-existent folders
+		return verify(path, p -> !Files.isRegularFile(p), "Not a file: ");
 	}
 
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/DecompileCommand.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
-import static org.quiltmc.enigma.command.CommonArguments.OUTPUT_JAR;
 
 public final class DecompileCommand extends Command<Required, Path> {
 	private static final Argument<String> DECOMPILER = Argument.ofLenientEnum("decompiler", Decompiler.class,
@@ -28,18 +27,24 @@ public final class DecompileCommand extends Command<Required, Path> {
 					.collect(Collectors.joining())
 	);
 
+	private static final Argument<Path> OUTPUT_DIR = Argument.ofFolder("output-dir",
+			"""
+				The directory to save decompiler output to.
+				"""
+	);
+
 	public static final DecompileCommand INSTANCE = new DecompileCommand();
 
 	private DecompileCommand() {
 		super(
-				ArgsParser.of(DECOMPILER, INPUT_JAR, OUTPUT_JAR, Required::new),
+				ArgsParser.of(DECOMPILER, INPUT_JAR, OUTPUT_DIR, Required::new),
 				ArgsParser.of(INPUT_MAPPINGS)
 		);
 	}
 
 	@Override
 	void runImpl(Required required, Path inputMappings) throws Exception {
-		run(required.decompiler, required.inputJar, required.outputJar, inputMappings);
+		run(required.decompiler, required.inputJar, required.outputDir, inputMappings);
 	}
 
 	@Override
@@ -56,7 +61,7 @@ public final class DecompileCommand extends Command<Required, Path> {
 		run(decompiler.toString(), fileJarIn, fileJarOut, fileMappings);
 	}
 
-	public static void run(String decompilerName, Path fileJarIn, Path fileJarOut, Path fileMappings) throws Exception {
+	public static void run(String decompilerName, Path fileJarIn, Path outputDir, Path fileMappings) throws Exception {
 		DecompilerService decompilerService;
 
 		try {
@@ -74,7 +79,7 @@ public final class DecompileCommand extends Command<Required, Path> {
 		EnigmaProject.JarExport jar = project.exportRemappedJar(progress);
 		EnigmaProject.SourceExport source = jar.decompile(progress, decompilerService, DecompileErrorStrategy.TRACE_AS_SOURCE);
 
-		source.write(fileJarOut, progress);
+		source.write(outputDir, progress);
 	}
 
 	public enum Decompiler {
@@ -83,5 +88,5 @@ public final class DecompileCommand extends Command<Required, Path> {
 		public static final ImmutableList<Decompiler> VALUES = ImmutableList.copyOf(values());
 	}
 
-	record Required(String decompiler, Path inputJar, Path outputJar) { }
+	record Required(String decompiler, Path inputJar, Path outputDir) { }
 }


### PR DESCRIPTION
Replaces `DecompileCommand`'s `OUTPUT_JAR` arg with new `OUTPUT_DIR` arg (**breaking**).
Also adds some more factories and utilities to `Argument`