### PR TITLE
Tab improvements

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorTabbedPane.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorTabbedPane.java
@@ -13,9 +13,6 @@ import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 
 import java.awt.Component;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Iterator;
 import javax.annotation.Nullable;
@@ -47,9 +44,9 @@ public class EditorTabbedPane {
 			this.navigator = new NavigatorPanel(this.gui);
 			EditorPanel ed = new EditorPanel(this.gui, this.navigator);
 			ed.setClassHandle(ch);
-			this.openFiles.addTab(ed.getFileName(), ed.getUi());
+			this.openFiles.addTab(ed.getSimpleClassName(), ed.getUi());
 
-			ClosableTabTitlePane titlePane = new ClosableTabTitlePane(ed.getFileName(), () -> this.closeEditor(ed));
+			ClosableTabTitlePane titlePane = new ClosableTabTitlePane(ed.getSimpleClassName(), ed.getFullClassName(), () -> this.closeEditor(ed));
 			this.openFiles.setTabComponentAt(this.openFiles.indexOfComponent(ed.getUi()), titlePane.getUi());
 			titlePane.setTabbedPane(this.openFiles);
 
@@ -69,7 +66,7 @@ public class EditorTabbedPane {
 
 				@Override
 				public void onTitleChanged(EditorPanel editor, String title) {
-					titlePane.setText(editor.getFileName());
+					titlePane.setText(editor.getSimpleClassName(), editor.getFullClassName());
 				}
 			});
 

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorTabbedPane.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorTabbedPane.java
@@ -13,6 +13,9 @@ import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
 import org.quiltmc.enigma.api.translation.representation.entry.Entry;
 
 import java.awt.Component;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.Iterator;
 import javax.annotation.Nullable;
@@ -98,6 +101,7 @@ public class EditorTabbedPane {
 		this.openFiles.remove(ed.getUi());
 		this.editors.inverse().remove(ed);
 		EditorPanel activeEditor = this.getActiveEditor();
+		activeEditor.getEditor().requestFocus();
 		this.gui.updateStructure(activeEditor);
 		this.gui.showCursorReference(activeEditor != null ? activeEditor.getCursorReference() : null);
 		ed.destroy();
@@ -151,6 +155,7 @@ public class EditorTabbedPane {
 			}
 
 			EditorPanel activeEditor = this.getActiveEditor();
+			activeEditor.getEditor().requestFocus();
 			this.gui.updateStructure(activeEditor);
 			this.gui.showCursorReference(activeEditor != null ? activeEditor.getCursorReference() : null);
 		}

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/ClosableTabTitlePane.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/ClosableTabTitlePane.java
@@ -11,9 +11,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeListener;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.Point;
+import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
@@ -82,6 +80,22 @@ public class ClosableTabTitlePane {
 					ClosableTabTitlePane.this.parent.dispatchEvent(e1);
 				}
 			}
+
+			@Override
+			public void mouseEntered(MouseEvent e) {
+				ClosableTabTitlePane.this.closeButton.setEnabled(true);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent e) {
+				if (!ClosableTabTitlePane.this.isActive(ClosableTabTitlePane.this.parent)) {
+					Component target = SwingUtilities.getDeepestComponentAt(e.getComponent(), e.getX(), e.getY());
+					if (!(target == ClosableTabTitlePane.this.closeButton)) {
+						// only disable if mouse is over neither tab nor close button
+						ClosableTabTitlePane.this.closeButton.setEnabled(false);
+					}
+				}
+			}
 		});
 
 		this.ui.putClientProperty(ClosableTabTitlePane.class, this);
@@ -110,15 +124,20 @@ public class ClosableTabTitlePane {
 	}
 
 	private void updateState(JTabbedPane pane) {
-		int selectedIndex = pane.getSelectedIndex();
-		boolean isActive = selectedIndex != -1 && pane.getTabComponentAt(selectedIndex) == this.ui;
-		this.closeButton.setEnabled(isActive);
-		this.closeButton.putClientProperty("paintActive", isActive);
+		final boolean active = this.isActive(pane);
+		this.closeButton.setEnabled(active);
+		this.closeButton.putClientProperty("paintActive", active);
 
 		this.ui.remove(this.closeButton);
 		this.ui.add(this.closeButton);
 
 		this.ui.repaint();
+	}
+
+	private boolean isActive(JTabbedPane pane) {
+		int selectedIndex = pane.getSelectedIndex();
+		boolean isActive = selectedIndex != -1 && pane.getTabComponentAt(selectedIndex) == this.ui;
+		return isActive;
 	}
 
 	public JPanel getUi() {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/ClosableTabTitlePane.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/ClosableTabTitlePane.java
@@ -18,16 +18,18 @@ import java.awt.event.MouseEvent;
 public class ClosableTabTitlePane {
 	private final JPanel ui;
 	private final JButton closeButton;
-	private final JLabel label;
+	private final JLabel title;
 
 	private ChangeListener cachedChangeListener;
 	private JTabbedPane parent;
 
-	public ClosableTabTitlePane(String text, Runnable onClose) {
+	public ClosableTabTitlePane(String title, String tooltip, Runnable onClose) {
 		this.ui = new JPanel(new FlowLayout(FlowLayout.CENTER, 2, 2));
 		this.ui.setOpaque(false);
-		this.label = new JLabel(text);
-		this.ui.add(this.label);
+
+		this.title = new JLabel(title);
+		this.title.setToolTipText(tooltip);
+		this.ui.add(this.title);
 
 		// Adapted from javax.swing.plaf.metal.MetalTitlePane
 		this.closeButton = new JButton();
@@ -115,12 +117,13 @@ public class ClosableTabTitlePane {
 		this.parent = pane;
 	}
 
-	public void setText(String text) {
-		this.label.setText(text);
+	public void setText(String title, String tooltip) {
+		this.title.setText(title);
+		this.title.setToolTipText(tooltip);
 	}
 
-	public String getText() {
-		return this.label.getText();
+	public String getTitle() {
+		return this.title.getText();
 	}
 
 	private void updateState(JTabbedPane pane) {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/EditorPanel.java
@@ -256,7 +256,7 @@ public class EditorPanel {
 		handle.addListener(new ClassHandleListener() {
 			@Override
 			public void onDeobfRefChanged(ClassHandle h, ClassEntry deobfRef) {
-				SwingUtilities.invokeLater(() -> EditorPanel.this.listeners.forEach(l -> l.onTitleChanged(EditorPanel.this, EditorPanel.this.getFileName())));
+				SwingUtilities.invokeLater(() -> EditorPanel.this.listeners.forEach(l -> l.onTitleChanged(EditorPanel.this, EditorPanel.this.getSimpleClassName())));
 			}
 
 			@Override
@@ -653,9 +653,17 @@ public class EditorPanel {
 		return this.classHandle;
 	}
 
-	public String getFileName() {
-		ClassEntry classEntry = this.classHandle.getDeobfRef() != null ? this.classHandle.getDeobfRef() : this.classHandle.getRef();
-		return classEntry.getSimpleName();
+	public String getSimpleClassName() {
+		return this.getDeobfOrObfHandleRef().getSimpleName();
+	}
+
+	public String getFullClassName() {
+		return this.getDeobfOrObfHandleRef().getFullName();
+	}
+
+	private ClassEntry getDeobfOrObfHandleRef() {
+		final ClassEntry deobfRef = this.classHandle.getDeobfRef();
+		return deobfRef == null ? this.classHandle.getRef() : deobfRef;
 	}
 
 	public void retranslateUi() {


### PR DESCRIPTION
- fixes #295
- focuses current tab editor after a tab is clicked or closed
- adds a tooltip to tab titles which shows the fully qualified class name