### PR TITLE
Print stats gen params

### DIFF
--- a/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
+++ b/enigma-cli/src/main/java/org/quiltmc/enigma/command/PrintStatsCommand.java
@@ -8,29 +8,61 @@ import org.quiltmc.enigma.api.stats.ProjectStatsResult;
 import org.quiltmc.enigma.api.stats.StatType;
 import org.quiltmc.enigma.api.stats.StatsGenerator;
 import org.quiltmc.enigma.command.PrintStatsCommand.Required;
+import org.quiltmc.enigma.command.PrintStatsCommand.Optional;
+import org.quiltmc.enigma.util.I18n;
 import org.tinylog.Logger;
 
 import javax.annotation.Nullable;
 import java.nio.file.Path;
+import java.util.EnumSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.quiltmc.enigma.command.CommonArguments.ENIGMA_PROFILE;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_JAR;
 import static org.quiltmc.enigma.command.CommonArguments.INPUT_MAPPINGS;
 
-public final class PrintStatsCommand extends Command<Required, Path> {
+public final class PrintStatsCommand extends Command<Required, Optional> {
+	private static final Argument<Set<StatType>> INCLUDED_TYPES = Argument.ofCollection(
+			"included-types", Argument.alternativesOf(StatType.class, "&|"),
+			"""
+				The stat types to include.""",
+			string -> Argument.parseCaseInsensitiveEnum(StatType.class, string),
+			Collectors.toUnmodifiableSet()
+	);
+
+	private static final Argument<Boolean> INCLUDE_SYNTHETIC = Argument.ofBool("include-synthetic",
+			"""
+				Whether to include synthetic entries."""
+	);
+
+	private static final Argument<Boolean> COUNT_FALLBACK = Argument.ofBool("count-fallback",
+			"""
+				Whether to count fallback-proposed entries as mapped."""
+	);
+
 	public static final PrintStatsCommand INSTANCE = new PrintStatsCommand();
 
 	private PrintStatsCommand() {
 		super(
 				ArgsParser.of(INPUT_JAR, INPUT_MAPPINGS, Required::new),
-				ArgsParser.of(ENIGMA_PROFILE)
+				ArgsParser.of(ENIGMA_PROFILE, INCLUDED_TYPES, INCLUDE_SYNTHETIC, COUNT_FALLBACK, Optional::new)
 		);
 	}
 
 	@Override
-	void runImpl(Required required, Path enigmaProfile) throws Exception {
-		run(required.inputJar, required.inputMappings, enigmaProfile, null);
+	void runImpl(Required required, Optional optional) throws Exception {
+		final Set<StatType> includedTypes = optional.includedTypes == null || optional.includedTypes.isEmpty()
+				? EnumSet.allOf(StatType.class)
+				: optional.includedTypes;
+
+		final GenerationParameters params = new GenerationParameters(
+					includedTypes,
+					Boolean.TRUE.equals(optional.includeSynthetic),
+					Boolean.TRUE.equals(optional.countFallback)
+		);
+
+		run(required.inputJar, required.inputMappings, optional.enigmaProfile, params, null);
 	}
 
 	@Override
@@ -43,24 +75,44 @@ public final class PrintStatsCommand extends Command<Required, Path> {
 		return "Generates and prints out the statistics of how well the provided mappings cover the provided JAR file.";
 	}
 
-	public static void run(Path inJar, Path mappings, @Nullable Path profilePath, @Nullable Iterable<EnigmaPlugin> plugins) throws Exception {
+	public static void run(
+			Path inJar, Path mappings, @Nullable Path profilePath,
+			@Nullable GenerationParameters params, @Nullable Iterable<EnigmaPlugin> plugins
+	) throws Exception {
 		EnigmaProfile profile = EnigmaProfile.read(profilePath);
 		Enigma enigma = createEnigma(profile, plugins);
 
-		run(inJar, mappings, enigma);
+		run(inJar, mappings, enigma, params);
 	}
 
-	public static void run(Path inJar, Path mappings, Enigma enigma) throws Exception {
+	public static void run(Path inJar, Path mappings, Enigma enigma, @Nullable GenerationParameters params) throws Exception {
 		StatsGenerator generator = new StatsGenerator(openProject(inJar, mappings, enigma));
-		ProjectStatsResult result = generator.generate(new ConsoleProgressListener(), new GenerationParameters(Set.of(StatType.values())));
 
-		Logger.info(String.format("Overall mapped: %.2f%% (%s / %s)", result.getPercentage(), result.getMapped(), result.getMappable()));
-		Logger.info(String.format("Classes: %.2f%% (%s / %s)", result.getPercentage(StatType.CLASSES), result.getMapped(StatType.CLASSES), result.getMappable(StatType.CLASSES)));
-		Logger.info(String.format("Fields: %.2f%% (%s / %s)", result.getPercentage(StatType.FIELDS), result.getMapped(StatType.FIELDS), result.getMappable(StatType.FIELDS)));
-		Logger.info(String.format("Methods: %.2f%% (%s / %s)", result.getPercentage(StatType.METHODS), result.getMapped(StatType.METHODS), result.getMappable(StatType.METHODS)));
-		Logger.info(String.format("Parameters: %.2f%% (%s / %s)", result.getPercentage(StatType.PARAMETERS), result.getMapped(StatType.PARAMETERS), result.getMappable(StatType.PARAMETERS)));
+		if (params == null) {
+			params = new GenerationParameters();
+		}
+
+		ProjectStatsResult result = generator.generate(new ConsoleProgressListener(), params);
+
+		final Set<StatType> includedTypes = params.includedTypes();
+
+		if (includedTypes.size() > 1) {
+			final String overall = I18n.translate("menu.file.stats.overall");
+			logResult(overall, result.getPercentage(), result.getMapped(), result.getMappable());
+		}
+
+		for (final StatType type : StatType.values()) {
+			if (includedTypes.contains(type)) {
+				logResult(type.getName(), result.getPercentage(type), result.getMapped(type), result.getMappable(type));
+			}
+		}
+	}
+
+	private static void logResult(String label, double percentage, int mapped, int mappable) {
+		Logger.info("%s: %.2f%% (%s / %s)".formatted(label, percentage, mapped, mappable));
 	}
 
 	record Required(Path inputJar, Path inputMappings) { }
+	record Optional(Path enigmaProfile, Set<StatType> includedTypes, Boolean includeSynthetic, Boolean countFallback) { }
 }
 

--- a/enigma-cli/src/test/java/org/quiltmc/enigma/command/PrintStatsCommandTest.java
+++ b/enigma-cli/src/test/java/org/quiltmc/enigma/command/PrintStatsCommandTest.java
@@ -2,8 +2,11 @@ package org.quiltmc.enigma.command;
 
 import org.junit.jupiter.api.Test;
 import org.quiltmc.enigma.TestUtil;
+import org.quiltmc.enigma.api.stats.GenerationParameters;
+import org.quiltmc.enigma.api.stats.StatType;
 
 import java.nio.file.Path;
+import java.util.Set;
 
 import static org.quiltmc.enigma.TestUtil.getResource;
 
@@ -14,6 +17,8 @@ public class PrintStatsCommandTest {
 	@Test
 	public void test() throws Exception {
 		// just here to manually verify output
-		PrintStatsCommand.run(JAR, MAPPINGS, null, null);
+		PrintStatsCommand.run(JAR, MAPPINGS, null, null, null);
+		final var customParams = new GenerationParameters(Set.of(StatType.CLASSES), true, true);
+		PrintStatsCommand.run(JAR, MAPPINGS, null, customParams, null);
 	}
 }


### PR DESCRIPTION
Closes #284

Also uses translations in `PrintStatsCommand` logging.

~Based on #282 because I'm using a util method it adds to `Argument`.~ rebased

~Ready once #282 is merged.~ ready