### PR TITLE
Fix 201

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/IdentifierPanel.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/panel/IdentifierPanel.java
@@ -160,12 +160,13 @@ public class IdentifierPanel {
 
 				// type
 				EntryIndex index = this.gui.getController().getProject().getJarIndex().getIndex(EntryIndex.class);
-				local.getParent().streamParameters(index)
+				final String paramDesc = local.getParent().streamParameters(index)
 					.filter(param -> param.getIndex() == local.getIndex())
 					.findAny()
-					.ifPresent(param -> {
-						th.addCopiableStringRow(I18n.translate("info_panel.identifier.type"), toReadableType(param.getDesc()));
-					});
+					.map(param -> toReadableType(param.getDesc()))
+					.orElseGet(() -> I18n.translate("info_panel.identifier.type.unknown"));
+
+				th.addCopiableStringRow(I18n.translate("info_panel.identifier.type"), paramDesc);
 			} else {
 				throw new IllegalStateException("unreachable");
 			}

--- a/enigma/src/main/resources/lang/en_us.json
+++ b/enigma/src/main/resources/lang/en_us.json
@@ -161,6 +161,7 @@
 	"info_panel.identifier.outer_class": "Outer class",
 	"info_panel.identifier.obfuscated": "Obfuscated Name",
 	"info_panel.identifier.type": "Type",
+	"info_panel.identifier.type.unknown": "<unknown>",
 	"info_panel.identifier.method_descriptor": "Method Descriptor",
 	"info_panel.identifier.index": "Index",
 	"info_panel.editor.class.decompiling": "(decompiling...)",


### PR DESCRIPTION
Fixes #201

`IdentifierPanel::refreshReference` passed deobf `LocalVariableEntry`s to `EntryIndex` which only contains obf entries.

This fixes that and:
- gets the param descriptor from `EntryIndex` instead of deriving it from the parent method
- eliminates the possibility of incorrect types in the `IdentifierPanel` due to index offsets
- shows `<unknown>` for the types of un-indexed locals (this should only happen for non-args)

~~Based on #282 because it adds param indexing.~~ rebased

~~Ready once #282 is merged.~~ ready