### PR TITLE
Sequential and cancelable stats reloads

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 public class ClassSelector extends JTree {
 	public static final Comparator<ClassEntry> DEOBF_CLASS_COMPARATOR = Comparator.comparing(ClassEntry::getFullName);
@@ -299,11 +300,11 @@ public class ClassSelector extends JTree {
 	 *
 	 * @param classEntry the class to reload stats for
 	 */
-	public RunnableFuture<?> reloadStats(ClassEntry classEntry, AtomicBoolean canceller) {
+	public RunnableFuture<?> reloadStats(ClassEntry classEntry, Supplier<Boolean> shouldCancel) {
 		ClassSelectorClassNode node = this.packageManager.getClassNode(classEntry);
 		return node == null
 				? Utils.DUMMY_RUNNABLE_FUTURE
-				: node.reloadStats(this.controller.getGui(), this, true, canceller);
+				: node.reloadStats(this.controller.getGui(), this, true, shouldCancel);
 	}
 
 	public interface ClassSelectionListener {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
@@ -6,6 +6,7 @@ import org.quiltmc.enigma.gui.node.ClassSelectorClassNode;
 import org.quiltmc.enigma.gui.node.SortedMutableTreeNode;
 import org.quiltmc.enigma.gui.util.GuiUtil;
 import org.quiltmc.enigma.api.translation.representation.entry.ClassEntry;
+import org.quiltmc.enigma.util.Utils;
 
 import javax.annotation.Nullable;
 import javax.swing.JTree;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.RunnableFuture;
 
 public class ClassSelector extends JTree {
 	public static final Comparator<ClassEntry> DEOBF_CLASS_COMPARATOR = Comparator.comparing(ClassEntry::getFullName);
@@ -296,11 +298,11 @@ public class ClassSelector extends JTree {
 	 *
 	 * @param classEntry the class to reload stats for
 	 */
-	public void reloadStats(ClassEntry classEntry) {
+	public RunnableFuture<Void> reloadStats(ClassEntry classEntry) {
 		ClassSelectorClassNode node = this.packageManager.getClassNode(classEntry);
-		if (node != null) {
-			node.reloadStats(this.controller.getGui(), this, true);
-		}
+		return node == null
+				? Utils.DUMMY_RUNNABLE_FUTURE
+				: node.reloadStats(this.controller.getGui(), this, true);
 	}
 
 	public interface ClassSelectionListener {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
@@ -19,8 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
 public class ClassSelector extends JTree {
@@ -299,11 +298,28 @@ public class ClassSelector extends JTree {
 	 * On completion, the class's stats icon will be updated.
 	 *
 	 * @param classEntry the class to reload stats for
+	 *
+	 * @return a future whose completion indicates that all asynchronous work has finished
 	 */
-	public RunnableFuture<?> reloadStats(ClassEntry classEntry, Supplier<Boolean> shouldCancel) {
+	public Future<?> reloadStats(ClassEntry classEntry) {
+		return this.reloadStats(classEntry, Utils.SUPPLY_FALSE);
+	}
+
+	/**
+	 * Requests an asynchronous reload of the stats for the given class.
+	 * On completion, the class's stats icon will be updated.
+	 *
+	 * @param classEntry   the class to reload stats for
+	 * @param shouldCancel a supplier that may be used to cancel asynchronous work if it returns
+	 *                     {@code true} before the work has started
+	 *
+	 * @return a future whose completion indicates that no asynchronous work remains, whether
+	 * because it was canceled using the passed {@code shouldCancel} method or because it finished normally
+	 */
+	public Future<?> reloadStats(ClassEntry classEntry, Supplier<Boolean> shouldCancel) {
 		ClassSelectorClassNode node = this.packageManager.getClassNode(classEntry);
 		return node == null
-				? Utils.DUMMY_RUNNABLE_FUTURE
+				? Utils.DUMMY_FUTURE
 				: node.reloadStats(this.controller.getGui(), this, true, shouldCancel);
 	}
 

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/ClassSelector.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ClassSelector extends JTree {
 	public static final Comparator<ClassEntry> DEOBF_CLASS_COMPARATOR = Comparator.comparing(ClassEntry::getFullName);
@@ -298,11 +299,11 @@ public class ClassSelector extends JTree {
 	 *
 	 * @param classEntry the class to reload stats for
 	 */
-	public RunnableFuture<Void> reloadStats(ClassEntry classEntry) {
+	public RunnableFuture<?> reloadStats(ClassEntry classEntry, AtomicBoolean canceller) {
 		ClassSelectorClassNode node = this.packageManager.getClassNode(classEntry);
 		return node == null
 				? Utils.DUMMY_RUNNABLE_FUTURE
-				: node.reloadStats(this.controller.getGui(), this, true);
+				: node.reloadStats(this.controller.getGui(), this, true, canceller);
 	}
 
 	public interface ClassSelectionListener {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/Gui.java
@@ -647,7 +647,7 @@ public class Gui {
 			.flatMap(docker -> docker instanceof ClassesDocker classes ? Stream.of(classes) : Stream.empty())
 			.flatMap(classes -> toUpdate.stream().<Runnable>map(updating -> () -> {
 				try {
-					classes.getClassSelector().reloadStats(updating, currentReloadCanceler).get();
+					classes.getClassSelector().reloadStats(updating, currentReloadCanceler::get).get();
 				} catch (InterruptedException | ExecutionException e) {
 					throw new RuntimeException(e);
 				}

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/node/ClassSelectorClassNode.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/node/ClassSelectorClassNode.java
@@ -16,8 +16,7 @@ import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.TreeNode;
 import java.util.Comparator;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.RunnableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.Future;
 import java.util.function.Supplier;
 
 public class ClassSelectorClassNode extends SortedMutableTreeNode {
@@ -43,18 +42,33 @@ public class ClassSelectorClassNode extends SortedMutableTreeNode {
 	 * Reloads the stats for this class node and updates the icon in the provided class selector.
 	 * Exits if no project is open.
 	 *
-	 * @param gui the current gui instance
-	 * @param selector the class selector to reload on
+	 * @param gui             the current gui instance
+	 * @param selector        the class selector to reload on
 	 * @param updateIfPresent whether to update the stats if they have already been generated for this node
+	 *
+	 * @return a future whose completion indicates that all asynchronous work has finished
 	 */
-	public RunnableFuture<?> reloadStats(Gui gui, ClassSelector selector, boolean updateIfPresent) {
-		return this.reloadStats(gui, selector, updateIfPresent, () -> false);
+	public Future<?> reloadStats(Gui gui, ClassSelector selector, boolean updateIfPresent) {
+		return this.reloadStats(gui, selector, updateIfPresent, Utils.SUPPLY_FALSE);
 	}
 
-	public RunnableFuture<?> reloadStats(Gui gui, ClassSelector selector, boolean updateIfPresent, Supplier<Boolean> shouldCancel) {
+	/**
+	 * Reloads the stats for this class node and updates the icon in the provided class selector.
+	 * Exits if no project is open.
+	 *
+	 * @param gui             the current gui instance
+	 * @param selector        the class selector to reload on
+	 * @param updateIfPresent whether to update the stats if they have already been generated for this node
+	 * @param shouldCancel    a supplier that may be used to cancel asynchronous work if it returns
+	 *                        {@code true} before the work has started
+	 *
+	 * @return a future whose completion indicates that no asynchronous work remains, whether
+	 * because it was canceled using the passed {@code shouldCancel} method or because it finished normally
+	 */
+	public Future<?> reloadStats(Gui gui, ClassSelector selector, boolean updateIfPresent, Supplier<Boolean> shouldCancel) {
 		StatsGenerator generator = gui.getController().getStatsGenerator();
 		if (generator == null) {
-			return Utils.DUMMY_RUNNABLE_FUTURE;
+			return Utils.DUMMY_FUTURE;
 		}
 
 		SwingWorker<ProjectStatsResult, Void> iconUpdateWorker = new SwingWorker<>() {

--- a/enigma/src/main/java/org/quiltmc/enigma/api/stats/ProjectStatsResult.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/stats/ProjectStatsResult.java
@@ -9,12 +9,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ProjectStatsResult implements StatsProvider {
 	private final EnigmaProject project;
 
 	private final Map<String, List<StatsResult>> packageToClasses = new HashMap<>();
-	private final Map<ClassEntry, StatsResult> stats = new HashMap<>();
+	private final Map<ClassEntry, StatsResult> stats = new ConcurrentHashMap<>();
 	private final Map<String, StatsResult> packageStats = new HashMap<>();
 
 	private StatsResult overall;

--- a/enigma/src/main/java/org/quiltmc/enigma/util/Utils.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/util/Utils.java
@@ -2,6 +2,7 @@ package org.quiltmc.enigma.util;
 
 import com.google.common.io.CharStreams;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -16,12 +17,44 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class Utils {
+	public static final RunnableFuture<Void> DUMMY_RUNNABLE_FUTURE = new RunnableFuture<>() {
+		@Override
+		public void run() { }
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			return false;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDone() {
+			return true;
+		}
+
+		@Override
+		public Void get() {
+			return null;
+		}
+
+		@Override
+		public Void get(long timeout, @Nonnull TimeUnit unit) {
+			return null;
+		}
+	};
+
 	public static String readStreamToString(InputStream in) throws IOException {
 		return CharStreams.toString(new InputStreamReader(in, StandardCharsets.UTF_8));
 	}

--- a/enigma/src/main/java/org/quiltmc/enigma/util/Utils.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/util/Utils.java
@@ -17,7 +17,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
-import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
@@ -25,10 +25,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 public class Utils {
-	public static final RunnableFuture<Void> DUMMY_RUNNABLE_FUTURE = new RunnableFuture<>() {
-		@Override
-		public void run() { }
-
+	public static final Future<Void> DUMMY_FUTURE = new Future<>() {
 		@Override
 		public boolean cancel(boolean mayInterruptIfRunning) {
 			return false;
@@ -54,6 +51,8 @@ public class Utils {
 			return null;
 		}
 	};
+
+	public static final Supplier<Boolean> SUPPLY_FALSE = () -> false;
 
 	public static String readStreamToString(InputStream in) throws IOException {
 		return CharStreams.toString(new InputStreamReader(in, StandardCharsets.UTF_8));


### PR DESCRIPTION
Fixes #271

Makes it so that `Gui::reloadStats`:
- attempts to cancel any incomplete asynchronous work it started in previous calls
- waits for any un-cancelable prior work to complete before starting the current call's work

I also made `ProjectStatsResult.stats` a `ConcurrentHashMap` because I got this `ConcurrentModificationException` once:
[enigma_crash-concurrent-reloadStats.log](https://github.com/user-attachments/files/22395888/enigma_crash-concurrent-reloadStats.log).

I *think* the exception was possible but rare before this PR, but it was inconsistent so I can't be certain.

Supersedes #286