### PR TITLE
Downgrade Vineflower to 1.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ tinylog = "2.7.0"
 quilt_config = "1.3.2"
 javaparser = "3.27.0"
 
-vineflower = "1.11.2"
+vineflower = "1.11.1"
 cfr = "0.2.2"
 procyon = "0.6.0"
 


### PR DESCRIPTION
A bug in Vineflower 1.11.2 (https://github.com/Vineflower/vineflower/issues/524) breaks everything. Rather than trying to work around it, I think it's better to just downgrade until it gets fixed.