### PR TITLE
Fix 348

### DIFF
--- a/enigma-server/src/main/java/org/quiltmc/enigma/network/DedicatedEnigmaServer.java
+++ b/enigma-server/src/main/java/org/quiltmc/enigma/network/DedicatedEnigmaServer.java
@@ -124,10 +124,10 @@ public class DedicatedEnigmaServer extends EnigmaServer {
 
 			EntryRemapper mappings;
 			if (!Files.exists(mappingsFile)) {
-				mappings = EntryRemapper.mapped(enigma, project.getCombinedIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), new HashEntryTree<>(), enigma.getNameProposalServices());
+				mappings = EntryRemapper.mapped(project, project.getRemapper().getJarProposedMappings(), new HashEntryTree<>());
 			} else {
 				Logger.info("Reading mappings...");
-				mappings = EntryRemapper.mapped(enigma, project.getCombinedIndex(), project.getMappingsIndex(), project.getRemapper().getJarProposedMappings(), readWriteService.get().read(mappingsFile), enigma.getNameProposalServices());
+				mappings = EntryRemapper.mapped(project, project.getRemapper().getJarProposedMappings(), readWriteService.get().read(mappingsFile));
 			}
 
 			PrintWriter log = new PrintWriter(Files.newBufferedWriter(logFile));

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/GuiController.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/GuiController.java
@@ -686,7 +686,7 @@ public class GuiController implements ClientPacketHandler {
 	}
 
 	public void createServer(String username, int port, char[] password) throws IOException {
-		this.server = new IntegratedEnigmaServer(this.project.getJarChecksum(), password, EntryRemapper.mapped(this.project.getEnigma(), this.project.getCombinedIndex(), this.project.getMappingsIndex(), new HashEntryTree<>(this.project.getRemapper().getJarProposedMappings()), new HashEntryTree<>(this.project.getRemapper().getDeobfMappings()), this.project.getEnigma().getNameProposalServices()), port);
+		this.server = new IntegratedEnigmaServer(this.project.getJarChecksum(), password, EntryRemapper.mapped(this.project, new HashEntryTree<>(this.project.getRemapper().getJarProposedMappings()), new HashEntryTree<>(this.project.getRemapper().getDeobfMappings())), port);
 		this.server.start();
 		this.client = new IntegratedEnigmaClient(this, "127.0.0.1", port);
 		this.client.connect();

--- a/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProject.java
+++ b/enigma/src/main/java/org/quiltmc/enigma/api/EnigmaProject.java
@@ -78,7 +78,7 @@ public class EnigmaProject {
 		this.jarChecksum = jarChecksum;
 
 		this.mappingsIndex = mappingsIndex;
-		this.remapper = EntryRemapper.mapped(this.enigma, this.combinedIndex, this.mappingsIndex, proposedNames, new HashEntryTree<>(), this.enigma.getNameProposalServices());
+		this.remapper = EntryRemapper.mapped(this, proposedNames, new HashEntryTree<>());
 	}
 
 	/**
@@ -97,12 +97,12 @@ public class EnigmaProject {
 			EntryTree<EntryMapping> mergedTree = EntryTreeUtil.merge(jarProposedMappings, mappings);
 
 			this.mappingsIndex.indexMappings(mergedTree, progress);
-			this.remapper = EntryRemapper.mapped(this.enigma, this.combinedIndex, this.mappingsIndex, jarProposedMappings, mappings, this.enigma.getNameProposalServices());
+			this.remapper = EntryRemapper.mapped(this, jarProposedMappings, mappings);
 		} else if (!jarProposedMappings.isEmpty()) {
 			this.mappingsIndex.indexMappings(jarProposedMappings, progress);
-			this.remapper = EntryRemapper.mapped(this.enigma, this.combinedIndex, this.mappingsIndex, jarProposedMappings, new HashEntryTree<>(), this.enigma.getNameProposalServices());
+			this.remapper = EntryRemapper.mapped(this, jarProposedMappings, new HashEntryTree<>());
 		} else {
-			this.remapper = EntryRemapper.empty(this.enigma, this.combinedIndex, this.enigma.getNameProposalServices());
+			this.remapper = EntryRemapper.empty(this);
 		}
 
 		// update dynamically proposed names

--- a/enigma/src/test/java/org/quiltmc/enigma/TestMainJarMapped.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/TestMainJarMapped.java
@@ -1,0 +1,70 @@
+package org.quiltmc.enigma;
+
+import org.junit.jupiter.api.Test;
+import org.quiltmc.enigma.api.Enigma;
+import org.quiltmc.enigma.api.EnigmaProject;
+import org.quiltmc.enigma.api.ProgressListener;
+import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
+import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingFileNameFormat;
+import org.quiltmc.enigma.api.translation.mapping.serde.MappingSaveParameters;
+import org.quiltmc.enigma.api.translation.representation.entry.LocalVariableEntry;
+import org.quiltmc.enigma.util.validation.ValidationContext;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestMainJarMapped {
+	private static final Path JAR = TestUtil.obfJar("main_jar_mapped");
+
+	public static final String TEST_CLASS_NAME = "a";
+
+	private static EnigmaProject openProject() {
+		try {
+			return Enigma.create().openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Tests that when a parameter of a main jar method that's inherited from a lib class is mapped,
+	 * the main jar's parameter is mapped; no lib mapping should be created.
+	 */
+	@Test
+	void test() throws IOException {
+		final EnigmaProject project = openProject();
+
+		final LocalVariableEntry equalsParam = TestEntryFactory.newParameter(
+				TestEntryFactory.newMethod(TEST_CLASS_NAME, "equals", "(Ljava/lang/Object;)Z"),
+				1
+		);
+
+		project.getRemapper().putMapping(new ValidationContext(null), equalsParam, new EntryMapping("object"));
+
+		final Path mappingsDir = Files.createTempDirectory("main_jar_mapped");
+		project.getEnigma()
+				.getReadWriteService(mappingsDir)
+				.orElseThrow()
+				.write(
+					project.getRemapper().getMappings(),
+					mappingsDir,
+					new MappingSaveParameters(MappingFileNameFormat.BY_DEOBF, false, null, null)
+				);
+
+		final List<Path> savedFiles = new LinkedList<>();
+		try (Stream<Path> paths = Files.walk(mappingsDir)) {
+			paths.filter(Files::isRegularFile).forEach(savedFiles::add);
+		}
+
+		assertEquals(1, savedFiles.size());
+
+		assertEquals(mappingsDir.resolve(TEST_CLASS_NAME + ".mapping"), savedFiles.get(0));
+	}
+}

--- a/enigma/src/test/java/org/quiltmc/enigma/input/main_jar_mapped/MainJarMapped.java
+++ b/enigma/src/test/java/org/quiltmc/enigma/input/main_jar_mapped/MainJarMapped.java
@@ -1,0 +1,8 @@
+package org.quiltmc.enigma.input.main_jar_mapped;
+
+public class MainJarMapped {
+	@Override
+	public boolean equals(Object o) {
+		return false;
+	}
+}


### PR DESCRIPTION
Fixes #348

#306 made `EntryRemapper` use the combined `JarIndex` instead of the main `JarIndex`

That allowed its `MappingValidator` to detect conflicts with inherited lib methods, but resulted in its `EntryResolver` resolving roots in lib classes.

This makes `EntryRemapper` use the combined index for its `MappingValidator` and the main index for its `EntryResolver`.

This required breaking changes to `EntryRemapper`'s factory methods.