### PR TITLE
Name via constructor

### DIFF
--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/Gui.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/Gui.java
@@ -434,8 +434,8 @@ public class Gui {
 		editor.navigateToToken(tokens.get(0));
 	}
 
-	public void showCursorReference(EntryReference<Entry<?>, Entry<?>> reference) {
-		this.infoPanel.setReference(reference == null ? null : reference.entry);
+	public void showCursorReference(@Nullable EntryReference<Entry<?>, Entry<?>> reference) {
+		this.infoPanel.setReference(reference);
 	}
 
 	public void startDocChange(EditorPanel editor) {

--- a/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorPopupMenu.java
+++ b/enigma-swing/src/main/java/org/quiltmc/enigma/gui/element/EditorPopupMenu.java
@@ -126,15 +126,15 @@ public class EditorPopupMenu {
 	}
 
 	public void updateUiState() {
-		EntryReference<Entry<?>, Entry<?>> ref = this.editor.getCursorReference();
-		Entry<?> referenceEntry = ref == null ? null : ref.entry;
+		EntryReference<Entry<?>, Entry<?>> reference = this.editor.getCursorReference();
+		Entry<?> referenceEntry = reference == null ? null : reference.entry;
 		GuiController controller = this.gui.getController();
 
 		boolean isClassEntry = referenceEntry instanceof ClassEntry;
 		boolean isFieldEntry = referenceEntry instanceof FieldEntry;
 		boolean isMethodEntry = referenceEntry instanceof MethodEntry me && !me.isConstructor();
 		boolean isConstructorEntry = referenceEntry instanceof MethodEntry me && me.isConstructor();
-		boolean isRenamable = ref != null && controller.getProject().isRenamable(ref);
+		boolean isRenamable = reference != null && controller.getProject().isRenamable(reference);
 
 		EditableType type = EditableType.fromEntry(referenceEntry);
 
@@ -150,11 +150,7 @@ public class EditorPopupMenu {
 		this.openNextItem.setEnabled(controller.hasNextReference());
 		this.toggleMappingItem.setEnabled(isRenamable && (type != null && this.gui.isEditable(type)));
 
-		if (referenceEntry != null && this.gui.getController().getProject().getRemapper().extendedDeobfuscate(referenceEntry).getType() == TokenType.DEOBFUSCATED) {
-			this.toggleMappingItem.setText(I18n.translate("popup_menu.reset_obfuscated"));
-		} else {
-			this.toggleMappingItem.setText(I18n.translate("popup_menu.mark_deobfuscated"));
-		}
+		this.translateToggleMappingItem(reference);
 	}
 
 	public void retranslateUi() {
@@ -170,10 +166,24 @@ public class EditorPopupMenu {
 		this.openEntryItem.setText(I18n.translate("popup_menu.declaration"));
 		this.openPreviousItem.setText(I18n.translate("popup_menu.back"));
 		this.openNextItem.setText(I18n.translate("popup_menu.forward"));
-		this.toggleMappingItem.setText(I18n.translate("popup_menu.mark_deobfuscated"));
 		this.zoomInItem.setText(I18n.translate("popup_menu.zoom.in"));
 		this.zoomOutMenu.setText(I18n.translate("popup_menu.zoom.out"));
 		this.resetZoomItem.setText(I18n.translate("popup_menu.zoom.reset"));
+
+		this.translateToggleMappingItem(this.editor.getCursorReference());
+	}
+
+	private void translateToggleMappingItem(EntryReference<Entry<?>, Entry<?>> reference) {
+		if (
+				reference != null && this.gui
+					.getController().getProject().getRemapper()
+					.extendedDeobfuscate(reference.getNameableEntry())
+					.getType() == TokenType.DEOBFUSCATED
+		) {
+			this.toggleMappingItem.setText(I18n.translate("popup_menu.reset_obfuscated"));
+		} else {
+			this.toggleMappingItem.setText(I18n.translate("popup_menu.mark_deobfuscated"));
+		}
 	}
 
 	public JPopupMenu getUi() {


### PR DESCRIPTION
- `IdentifierPanel`:
  -  checks the nameability of the cursor's reference instead of its reference's entry in `TableHelper`; fixes #350
  - removes redundant inner/outer class checks when getting `ClassEntry` names; `getName` already returns the simple same for inner classes and the full name for outer classes
- `EditorPopupMenu`:
  -  accounts for cursor state in `EditorPopupMenu::retranslateUi`
  - checks the nameability of the cursor's reference instead of its reference's entry when setting `toggleMappingItem`'s text; fixes the text always being "Mark as deobfuscated" for constructors; even when deobfuscated