### PR TITLE
Mostly fix `NetworkTest`

### DIFF
--- a/enigma-server/src/main/java/org/quiltmc/enigma/network/EnigmaServer.java
+++ b/enigma-server/src/main/java/org/quiltmc/enigma/network/EnigmaServer.java
@@ -87,7 +87,8 @@ public abstract class EnigmaServer {
 		thread.start();
 	}
 
-	private void acceptClient() throws IOException {
+	@VisibleForTesting
+	Socket acceptClient() throws IOException {
 		Socket client = this.socket.accept();
 		this.clients.add(client);
 		this.unapprovedClients.add(client);
@@ -127,6 +128,8 @@ public abstract class EnigmaServer {
 		thread.setName("Server I/O thread #" + (nextIoId++));
 		thread.setDaemon(true);
 		thread.start();
+
+		return client;
 	}
 
 	public void stop() {

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/DummyClientPacketHandler.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/DummyClientPacketHandler.java
@@ -1,5 +1,7 @@
 package org.quiltmc.enigma.network;
 
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Assertions;
 import org.quiltmc.enigma.api.translation.mapping.EntryChange;
 import org.quiltmc.enigma.api.translation.mapping.EntryMapping;
 import org.quiltmc.enigma.api.translation.mapping.tree.EntryTree;
@@ -10,6 +12,7 @@ import java.util.concurrent.CountDownLatch;
 
 public class DummyClientPacketHandler implements ClientPacketHandler {
 	TestEnigmaClient client;
+	@NonNull
 	CountDownLatch disconnectFromServerLatch = new CountDownLatch(1);
 
 	@Override
@@ -24,13 +27,11 @@ public class DummyClientPacketHandler implements ClientPacketHandler {
 	@SuppressWarnings("deprecation")
 	@Override
 	public void disconnectIfConnected(String reason) {
-		if (this.client != null) {
-			this.client.disconnect();
-		}
+		Assertions.assertNotNull(this.client, "No client!");
+		this.client.disconnect();
 
-		if (this.disconnectFromServerLatch != null) {
-			this.disconnectFromServerLatch.countDown();
-		}
+		Assertions.assertNotNull(this.disconnectFromServerLatch, "No disconnection latch!");
+		this.disconnectFromServerLatch.countDown();
 	}
 
 	@Override

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/DummyClientPacketHandler.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/DummyClientPacketHandler.java
@@ -21,6 +21,7 @@ public class DummyClientPacketHandler implements ClientPacketHandler {
 		return true;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
 	public void disconnectIfConnected(String reason) {
 		if (this.client != null) {

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -167,6 +167,8 @@ public class NetworkTest {
 		handler.client = client1;
 		client1.sendPacket(packet);
 
+		busyAwaitConnection();
+
 		final var handler2 = new DummyClientPacketHandler();
 		final TestEnigmaClient client2 = connectClient(handler2);
 		handler2.client = client2;

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -68,6 +68,10 @@ public class NetworkTest {
 		return client;
 	}
 
+	private static void awaitNextConnection() throws InterruptedException {
+		Assertions.assertTrue(server.awaitNextConnection(3, TimeUnit.SECONDS), "Client did not connect");
+	}
+
 	/**
 	 * <b>Never</b> directly {@linkplain EnigmaClient#disconnect() disconnect} clients after tests; <b>always</b>
 	 * either manually {@link EnigmaServer#kick(Socket, String) kick} them (like this method does) or wait for them to
@@ -82,7 +86,7 @@ public class NetworkTest {
 		server.kick(clientSocket, "test complete");
 	}
 
-	@RepeatedTest(100000)
+	@RepeatedTest(DEFAULT_REPETITIONS)
 	public void testLogin() throws IOException, InterruptedException {
 		final var handler = new DummyClientPacketHandler();
 
@@ -91,7 +95,7 @@ public class NetworkTest {
 		final TestEnigmaClient client = connectClient(handler);
 		handler.client = client;
 
-		Assertions.assertTrue(server.awaitNextConnection(3, TimeUnit.SECONDS), "Client did not connect");
+		awaitNextConnection();
 
 		Assertions.assertNotEquals(0, handler.disconnectFromServerLatch.getCount(), "The client was disconnected by the server");
 
@@ -142,7 +146,7 @@ public class NetworkTest {
 		handler.client = client1;
 		client1.sendPacket(packet);
 
-		Assertions.assertTrue(server.awaitNextConnection(3, TimeUnit.SECONDS), "Client did not connect");
+		awaitNextConnection();
 
 		final var handler2 = new DummyClientPacketHandler();
 

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -158,7 +158,7 @@ public class NetworkTest {
 		Assertions.assertTrue(disconnected, "Timed out waiting for the server to kick the client");
 	}
 
-	@RepeatedTest(DEFAULT_REPETITIONS)
+	@RepeatedTest(1000)
 	public void testTakenUsername() throws IOException, InterruptedException {
 		final var packet = new LoginC2SPacket(checksum, PASSWORD.toCharArray(), "alice");
 
@@ -166,10 +166,6 @@ public class NetworkTest {
 		final TestEnigmaClient client1 = connectClient(handler);
 		handler.client = client1;
 		client1.sendPacket(packet);
-
-		final List<Socket> clients = server.getClients();
-		Assertions.assertEquals(clients.size(), 1, "Expected exactly one client");
-		final Socket client1Socket = clients.get(0);
 
 		final var handler2 = new DummyClientPacketHandler();
 		final TestEnigmaClient client2 = connectClient(handler2);
@@ -180,7 +176,9 @@ public class NetworkTest {
 
 		Assertions.assertTrue(disconnected, "Timed out waiting for the server to kick the client");
 
-		kickAfterTest(client1Socket);
+		for (final Socket clientSocket : List.copyOf(server.getClients())) {
+			kickAfterTest(clientSocket);
+		}
 	}
 
 	@RepeatedTest(DEFAULT_REPETITIONS)

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -158,7 +158,8 @@ public class NetworkTest {
 		Assertions.assertTrue(disconnected, "Timed out waiting for the server to kick the client");
 	}
 
-	@RepeatedTest(1000)
+	// FIXME this test is flaky when run from workflows/build.yml
+	@Test
 	public void testTakenUsername() throws IOException, InterruptedException {
 		final var packet = new LoginC2SPacket(checksum, PASSWORD.toCharArray(), "alice");
 

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -150,8 +150,12 @@ public class NetworkTest {
 
 		final var handler2 = new DummyClientPacketHandler();
 
+		server.queueConnectionWait();
+
 		final TestEnigmaClient client2 = connectClient(handler2);
 		handler2.client = client2;
+
+		awaitNextConnection();
 
 		client2.sendPacket(packet);
 		final boolean disconnected = handler2.disconnectFromServerLatch.await(3, TimeUnit.SECONDS);

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -10,27 +10,43 @@ import org.quiltmc.enigma.api.Enigma;
 import org.quiltmc.enigma.api.EnigmaProject;
 import org.quiltmc.enigma.api.ProgressListener;
 import org.quiltmc.enigma.api.class_provider.ClasspathClassProvider;
-import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 import org.quiltmc.enigma.network.packet.c2s.LoginC2SPacket;
 import org.quiltmc.enigma.network.packet.c2s.MessageC2SPacket;
 import org.quiltmc.enigma.network.packet.s2c.KickS2CPacket;
 import org.quiltmc.enigma.util.Utils;
 
 import java.io.IOException;
+import java.net.BindException;
 import java.net.Socket;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+/**
+ * <b>Warning</b>: Using {@link RepeatedTest @RepeatedTest} on tests that wait on
+ * {@link DummyClientPacketHandler#disconnectFromServerLatch} eventually causes
+ * {@link BindException}: {@code Address already in use: connect}.
+ *
+ * <p> It seems like all outbound sockets get exhausted and have a timeout before they become available.
+ *
+ * <p> On my (supersaiyansubtlety's) PC, the first exception comes after ~20,000 combined repetitions within ~2 minutes,
+ * after which exceptions are frequently thrown until ~2 minutes have passed without any repetitions.
+ *
+ * <p> Each {@link DummyClientPacketHandler#disconnectFromServerLatch}-waiting test succeeded with 1,000 repetitions.
+ *
+ * <p> Repetitions are set to {@value #DEFAULT_REPETITIONS} to reasonably test flakiness while avoiding the socket cap.
+ */
 public class NetworkTest {
 	private static final Path JAR = TestUtil.obfJar("complete");
 	private static final String PASSWORD = "foobar";
+	private static final int DEFAULT_REPETITIONS = 100;
+
 	private static byte[] checksum;
 	private static TestEnigmaServer server;
-	private static EntryRemapper remapper;
 
 	/**
 	 * <b>HACK</b>: busy waiting using {@link Thread#sleep(long)} in a {@code while} loop.
@@ -56,7 +72,7 @@ public class NetworkTest {
 
 	private static void busyAwaitConnection() {
 		busyAwaitNot(
-				"Client did not connect", 100,
+				"Client did not connect", DEFAULT_REPETITIONS,
 				() -> server.getClients().isEmpty() || server.getUnapprovedClients().isEmpty()
 		);
 	}
@@ -67,8 +83,7 @@ public class NetworkTest {
 		EnigmaProject project = enigma.openJar(JAR, new ClasspathClassProvider(), ProgressListener.createEmpty());
 
 		checksum = Utils.zipSha1(JAR);
-		remapper = project.getRemapper();
-		server = new TestEnigmaServer(checksum, PASSWORD.toCharArray(), remapper, 0);
+		server = new TestEnigmaServer(checksum, PASSWORD.toCharArray(), project.getRemapper(), 0);
 
 		server.start();
 	}
@@ -99,10 +114,10 @@ public class NetworkTest {
 		server.kick(clientSocket, "test complete");
 	}
 
-	@RepeatedTest(100000)
+	@RepeatedTest(DEFAULT_REPETITIONS)
 	public void testLogin() throws IOException, InterruptedException {
-		var handler = new DummyClientPacketHandler();
-		var client = connectClient(handler);
+		final var handler = new DummyClientPacketHandler();
+		final TestEnigmaClient client = connectClient(handler);
 		handler.client = client;
 
 		busyAwaitConnection();
@@ -119,22 +134,19 @@ public class NetworkTest {
 		kickAfterTest(clientSocket);
 	}
 
-	@RepeatedTest(100000)
+	@RepeatedTest(DEFAULT_REPETITIONS)
 	public void testInvalidUsername() throws IOException, InterruptedException {
 		var handler = new DummyClientPacketHandler();
-		// TODO this can throw java.net.BindException despite awaiting disconnectFromServerLatch and disconnecting below
 		var client = connectClient(handler);
 		handler.client = client;
 
 		client.sendPacket(new LoginC2SPacket(checksum, PASSWORD.toCharArray(), "<span style=\"color: lavender\">eve</span>"));
-		var disconnected = handler.disconnectFromServerLatch.await(3, TimeUnit.SECONDS);
+		boolean disconnected = handler.disconnectFromServerLatch.await(3, TimeUnit.SECONDS);
 
 		Assertions.assertTrue(disconnected, "Timed out waiting for the server to kick the client");
-		// TODO remove
-		client.disconnect();
 	}
 
-	@Test
+	@RepeatedTest(DEFAULT_REPETITIONS)
 	public void testWrongPassword() throws IOException, InterruptedException {
 		var handler = new DummyClientPacketHandler();
 		var client = connectClient(handler);
@@ -144,31 +156,34 @@ public class NetworkTest {
 		var disconnected = handler.disconnectFromServerLatch.await(3, TimeUnit.SECONDS);
 
 		Assertions.assertTrue(disconnected, "Timed out waiting for the server to kick the client");
-		client.disconnect();
 	}
 
-	@Test
+	@RepeatedTest(DEFAULT_REPETITIONS)
 	public void testTakenUsername() throws IOException, InterruptedException {
-		var packet = new LoginC2SPacket(checksum, PASSWORD.toCharArray(), "alice");
+		final var packet = new LoginC2SPacket(checksum, PASSWORD.toCharArray(), "alice");
 
-		var handler = new DummyClientPacketHandler();
-		var client = connectClient(handler);
-		handler.client = client;
-		client.sendPacket(packet);
+		final var handler = new DummyClientPacketHandler();
+		final TestEnigmaClient client1 = connectClient(handler);
+		handler.client = client1;
+		client1.sendPacket(packet);
 
-		var handler2 = new DummyClientPacketHandler();
-		var client2 = connectClient(handler2);
+		final List<Socket> clients = server.getClients();
+		Assertions.assertEquals(clients.size(), 1, "Expected exactly one client");
+		final Socket client1Socket = clients.get(0);
+
+		final var handler2 = new DummyClientPacketHandler();
+		final TestEnigmaClient client2 = connectClient(handler2);
 		handler2.client = client2;
 
 		client2.sendPacket(packet);
-		var disconnected = handler2.disconnectFromServerLatch.await(3, TimeUnit.SECONDS);
+		final boolean disconnected = handler2.disconnectFromServerLatch.await(3, TimeUnit.SECONDS);
 
 		Assertions.assertTrue(disconnected, "Timed out waiting for the server to kick the client");
-		client.disconnect();
-		client2.disconnect();
+
+		kickAfterTest(client1Socket);
 	}
 
-	@Test
+	@RepeatedTest(DEFAULT_REPETITIONS)
 	public void testWrongChecksum() throws IOException, InterruptedException {
 		var handler = new DummyClientPacketHandler();
 		var client = connectClient(handler);
@@ -179,9 +194,9 @@ public class NetworkTest {
 		var disconnected = handler.disconnectFromServerLatch.await(3, TimeUnit.SECONDS);
 
 		Assertions.assertTrue(disconnected, "Timed out waiting for the server to kick the client");
-		client.disconnect();
 	}
 
+	// no repeats because successes take at least 3 seconds
 	@Test
 	public void testUnapprovedMessage() throws IOException, InterruptedException {
 		var handler = new DummyClientPacketHandler();

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -134,7 +134,7 @@ public class NetworkTest {
 	}
 
 	// FIXME this test is flaky when run from workflows/build.yml
-	@RepeatedTest(10000)
+	@Test
 	public void testTakenUsername() throws IOException, InterruptedException {
 		final var packet = new LoginC2SPacket(checksum, PASSWORD.toCharArray(), "alice");
 

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/NetworkTest.java
@@ -86,6 +86,9 @@ public class NetworkTest {
 		server.kick(clientSocket, "test complete");
 	}
 
+	/**
+	 * When making changes to this test, <em>always</em> test with 100,000 repetitions.
+	 */
 	@RepeatedTest(DEFAULT_REPETITIONS)
 	public void testLogin() throws IOException, InterruptedException {
 		final var handler = new DummyClientPacketHandler();

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/TestEnigmaClient.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/TestEnigmaClient.java
@@ -2,6 +2,7 @@ package org.quiltmc.enigma.network;
 
 import org.quiltmc.enigma.network.packet.Packet;
 
+import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
 
 public class TestEnigmaClient extends EnigmaClient {
@@ -23,5 +24,14 @@ public class TestEnigmaClient extends EnigmaClient {
 		if (this.packetSentLatch != null) {
 			this.packetSentLatch.countDown();
 		}
+	}
+
+	/**
+	 * Don't call this at the end of a test; use {@link NetworkTest#kickAfterTest(Socket)} instead.
+	 */
+	@Override
+	@Deprecated
+	public synchronized void disconnect() {
+		super.disconnect();
 	}
 }

--- a/enigma-server/src/test/java/org/quiltmc/enigma/network/TestEnigmaServer.java
+++ b/enigma-server/src/test/java/org/quiltmc/enigma/network/TestEnigmaServer.java
@@ -1,6 +1,7 @@
 package org.quiltmc.enigma.network;
 
 import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Assertions;
 import org.quiltmc.enigma.api.translation.mapping.EntryRemapper;
 
 import java.io.IOException;
@@ -52,6 +53,7 @@ public class TestEnigmaServer extends EnigmaServer {
 	}
 
 	public void queueConnectionWait() {
+		Assertions.assertEquals(0, this.connectionLatch.getCount());
 		this.connectionLatch = new CountDownLatch(1);
 	}
 


### PR DESCRIPTION
*Mostly* fixes `NetworkTest` flakiness.

Merry happy.

---

- waits for client connection in `testLogin` and `testTakenUsername` to avoid race conditions
- removes unnecessary `EnigmaClient::disconnect` calls after waiting on `DummyClientPacketHandler.disconnectFromServerLatch`
- kicks clients instead of directly disconnecting them when not waiting on the disconnection latch;
  fixes race condition where the `kick` calls of servers' client threads sent packets that were received by other tests' clients
- adds repetitions to most tests

---

> [!WARNING]
> `testTakenUsername` is still flaky on CI

I didn't add repetitions for `testTakenUsername` because it's still flaky on CI; I can't reproduce the failures locally.

I thought the issue might be that the build workflow runs on jdk 17+20 were interfering with each other, but it's still flaky when they're sequential (10,000 reps here):
- [sequential build](https://github.com/supersaiyansubtlety/enigma/blob/fix-NetworkTest-countdown-sequential-build/.github/workflows/build.yml#L11)
- [run failure](https://github.com/supersaiyansubtlety/enigma/actions/runs/20512753501/job/58935732156#step:4:225)